### PR TITLE
Fixed bug with InputTag overflow triggering too soon

### DIFF
--- a/components/InputTags.tsx
+++ b/components/InputTags.tsx
@@ -134,8 +134,6 @@ function TagContainer({disabled, readOnly, tags, removeTag} : Pick<I_InputTagsPr
             "expand width to fit children" behaviour.
         */
 
-        console.log("Called");
-
         if( tags === undefined 
             || tagContainerRef === null 
             || tagContainerRef.current === null){
@@ -144,8 +142,6 @@ function TagContainer({disabled, readOnly, tags, removeTag} : Pick<I_InputTagsPr
 
         const width : number = tagContainerRef.current.clientWidth;
         const scrollWidth : number = tagContainerRef.current.scrollWidth;
-
-        console.log(`width === ${width}, scrollWidth === ${scrollWidth}`);
 
         if(scrollWidth > width){
             setOverflowingTags(true);

--- a/components/InputTags.tsx
+++ b/components/InputTags.tsx
@@ -24,13 +24,12 @@ const StyledTagContainer = styled.div<{hasOverflow : boolean, readOnly : boolean
     gap: ${TAG_CONTAINER_GAP};
     max-width: ${props => props.readOnly ? "100%" : TAG_CONTAINER_MAX_WIDTH};
 
-    overflow-y: hidden;
-
     ${ props => {
         if(props.hasOverflow){
             return css`
                 min-width: ${props.readOnly ? "100%" : TAG_CONTAINER_MAX_WIDTH};
                 overflow-x: auto;
+                overflow-y: hidden;
 
                 // Firefox doesn't support the webkit prefixed properties, but does support these two
                 scrollbar-color: ${PALETTE.blackStrong} ${PALETTE.blackMedium};
@@ -55,6 +54,8 @@ const StyledTagContainer = styled.div<{hasOverflow : boolean, readOnly : boolean
         } 
     }}
 `;
+
+
 
 const StyledTagInput = styled.input.attrs({ type: "text" })`
     ${resetCss}
@@ -133,6 +134,8 @@ function TagContainer({disabled, readOnly, tags, removeTag} : Pick<I_InputTagsPr
             "expand width to fit children" behaviour.
         */
 
+        console.log("Called");
+
         if( tags === undefined 
             || tagContainerRef === null 
             || tagContainerRef.current === null){
@@ -141,6 +144,8 @@ function TagContainer({disabled, readOnly, tags, removeTag} : Pick<I_InputTagsPr
 
         const width : number = tagContainerRef.current.clientWidth;
         const scrollWidth : number = tagContainerRef.current.scrollWidth;
+
+        console.log(`width === ${width}, scrollWidth === ${scrollWidth}`);
 
         if(scrollWidth > width){
             setOverflowingTags(true);


### PR DESCRIPTION
InputTag overflow triggered too soon, messing up the dynamic resizing as initial tags are entered.
Solved by moving "overflow-y: hidden" into the "hasOverflow" conditional block.