### PR TITLE
Apply reset CSS via preview.js

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,5 @@
+import '../styles/reset.css';
+
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
   controls: {

--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -80,17 +80,6 @@ function getUnicodeAndLabel(emoji : AvatarOptions | undefined){
     }
 }
 
-// const StyledDiv = styled.div`
-//     border-radius: 50%;
-//     background: ${ PALETTE.grayL };
-//     height: 3.25rem;
-//     width: 3.25rem;
-
-//     display: flex;
-//     align-items: center;
-//     justify-content: center;
-// `;
-
 const StyledAvatarEmoji = styled.span`
     line-height: 1.875rem;
     font-size: 1.875rem;

--- a/components/Badge.tsx
+++ b/components/Badge.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { ThemeProvider } from 'styled-components';
 import { PALETTE, SHADOW, TYPOGRAPHY } from './Theme';
-import { isBlank, resetCss } from './utils';
-import Paragraph from './Paragraph';
-
+import { isBlank } from './utils';
 
 export enum BadgeType{
     primary = "primary",
@@ -68,7 +66,6 @@ const StyledBadge = styled.div.attrs(props => ({
     border: 1px solid ${props => props.theme.borderColor};
     border-radius: 6.25rem;
     box-shadow: ${props => props.theme.shadow};
-    box-sizing: border-box;
     color: ${props => props.theme.color};
     filter: ${props => props.filter };
     font-family: var(--fontMain);
@@ -80,7 +77,6 @@ const StyledBadge = styled.div.attrs(props => ({
 `;
 
 const StyledBadgeText = styled.p`
-    ${resetCss}
     ${TYPOGRAPHY.p3Bold}
     color: ${props => props.theme.color};
     overflow: hidden;

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -259,25 +259,11 @@ const themePicker = (style : ButtonTheme) : ButtonThemeProps => {
 };
 
 
-const buttonResetCss = css`
-    font-size: 1rem;
-    line-height: 1.5rem;
-    margin: 0;
-    overflow: visible;
-    text-transform: none;
-    -webkit-appearance: button;
-    border: none;
-`;
-
-
 const StyledButton = styled.button<StyledButtonProps>`
-    ${ buttonResetCss }
-
     align-items: center;
     background: ${ props => props.theme.mainBackground }; 
     border-radius: ${ props  => props.circle ? "9999px" :  LAYOUT.borderRadius };
     box-shadow: inset 0px 0px 0px 0.125rem ${ props => props.theme.mainBorder };
-    box-sizing: border-box;
     color: ${ props => props.theme.mainColor };
     display: flex;
     font-family: ${ FONT.main };

--- a/components/Checkbox.tsx
+++ b/components/Checkbox.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { PALETTE, FONT, LAYOUT, ICON_SIZES } from './Theme';
+import { PALETTE, FONT, LAYOUT } from './Theme';
 import Icon from './Icons';
 import { IconSmallId } from './IconsSmall';
 
@@ -45,7 +45,6 @@ const StyledCheckbox = styled.input<Pick<CheckboxProps, "error">>`
     border-radius: ${ LAYOUT.borderRadius };
     border-style: solid;
     border-width: 0.0625rem;
-    box-sizing: border-box;
     height: 1.5rem;
     font: inherit;
     overflow: hidden;
@@ -66,7 +65,6 @@ const StyledCheckbox = styled.input<Pick<CheckboxProps, "error">>`
         content: "";
         width: 1.5rem;
         height: 1.5rem;
-        box-sizing: border-box;
         transform: scale(0);
         transition: 30ms transform ease-in-out;
         background: ${ PALETTE.primary };

--- a/components/CircleAroundIcon.tsx
+++ b/components/CircleAroundIcon.tsx
@@ -8,8 +8,6 @@ const StyledCircleContainer = styled.div<Pick<CircleAroundIconProps, "color" | "
     height: ${ props => props.size };
     width: ${ props => props.size };
 
-    box-sizing: border-box;
-
     display: flex;
     align-items: center;
     justify-content: center;

--- a/components/ContextMenu.tsx
+++ b/components/ContextMenu.tsx
@@ -11,7 +11,6 @@ const StyledContextMenu = styled.div<Coords>`
     background: ${PALETTE.white};
     border-radius: ${LAYOUT.borderRadius};
     box-shadow: ${ SHADOW.contextMenu };
-    box-sizing: border-box;
     left: ${props => props.x}px;
     overflow: hidden;
     padding: 0.25rem 0 0.35rem;

--- a/components/ContextMenuLi.tsx
+++ b/components/ContextMenuLi.tsx
@@ -9,7 +9,6 @@ const StyledMenuLi = styled.li`
     ${ TYPOGRAPHY.p2 }
 
     background: ${PALETTE.white};
-    box-sizing: border-box;
     display: flex;
     justify-content: space-between;
     padding: 0.5rem 0.75rem 0.5rem 1rem;

--- a/components/ContextMenuUl.tsx
+++ b/components/ContextMenuUl.tsx
@@ -3,15 +3,6 @@ import styled, {css} from 'styled-components';
 import {PALETTE, TYPOGRAPHY} from './Theme';
 import ContextMenuLi, {MenuItemProps} from './ContextMenuLi';
 
-const resetUl = css`
-    list-style: none;
-    padding: 0;
-    margin: 0;
-`;
-
-const StyledMenuUl = styled.ul`
-    ${resetUl}
-`;
 
 const StyledMenuHeading = styled.h1`
     ${ TYPOGRAPHY.p3 }
@@ -34,7 +25,7 @@ export default function MenuList({ heading, listItems } : MenuListProps ){
                 }
                 {
                     listItems.length > 0 &&
-                    <StyledMenuUl>
+                    <ul>
                         {
                             listItems.map((data, index) => {
                                 return <ContextMenuLi   key = {index}
@@ -44,7 +35,7 @@ export default function MenuList({ heading, listItems } : MenuListProps ){
                                         />
                             })
                         }
-                    </StyledMenuUl>
+                    </ul>
                 }
             </>
 }

--- a/components/ContextMenuUl.tsx
+++ b/components/ContextMenuUl.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled, {css} from 'styled-components';
 import {PALETTE, TYPOGRAPHY} from './Theme';
-import {resetCss} from './utils';
 import ContextMenuLi, {MenuItemProps} from './ContextMenuLi';
 
 const resetUl = css`
@@ -15,7 +14,6 @@ const StyledMenuUl = styled.ul`
 `;
 
 const StyledMenuHeading = styled.h1`
-    ${resetCss}
     ${ TYPOGRAPHY.p3 }
     background: ${PALETTE.grayM};
     padding: 0.6rem 0.75rem 0.65rem 1rem;

--- a/components/Files.tsx
+++ b/components/Files.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import {LAYOUT, PALETTE, SHADOW, TYPOGRAPHY} from './Theme';
-import {resetCss} from './utils';
 import CircleAroundIcon from './CircleAroundIcon';
 import Avatar, {AvatarOptions} from './Avatar';
 import Icon from './Icons';
@@ -30,7 +29,6 @@ const DROP_ZONE_HEIGHT_TO_PREVENT_FLICKERING_BUG = "5.25rem";
 
 
 const StyledDeleteButton = styled.button`
-    ${resetCss}
     ${TYPOGRAPHY.p3}
     background: transparent;
     color: ${PALETTE.primary};
@@ -85,7 +83,6 @@ const StyledLabelFile = styled.label`
 `;
 
 const StyledLayout = styled.div`
-    box-sizing: border-box;
     display: grid;
     gap: 0.5rem;
     grid-template-areas: "heading icon" "message icon";
@@ -113,13 +110,11 @@ const StyledLayoutActiveDrag = styled.div`
 `;
 
 const StyledPHeading = styled.p`
-    ${resetCss}
     ${TYPOGRAPHY.p2}
     grid-area: heading;
 `;
 
 const StyledPMessage = styled.p<{isError : boolean}>`
-    ${resetCss}
     ${TYPOGRAPHY.p3}
     color: ${props => props.isError ? PALETTE.red : PALETTE.blackStrong};
     grid-area: message;

--- a/components/IconsMedium.tsx
+++ b/components/IconsMedium.tsx
@@ -1,5 +1,3 @@
-//import React from 'react';
-
 export enum IconMediumId{
     copy,
     lock,

--- a/components/InputContainer.tsx
+++ b/components/InputContainer.tsx
@@ -1,10 +1,8 @@
 import styled, {css} from 'styled-components';
 import { PALETTE, LAYOUT, SHADOW, TYPOGRAPHY } from './Theme';
-import {resetCss} from './utils';
 
 const StyledInputContainer = styled.div<{disabled : boolean, isError : boolean, isSuccess : boolean, readOnly : boolean}>`
     border-radius: ${LAYOUT.borderRadius};
-    box-sizing: border-box;
     height: 3.5rem;
     overflow: hidden;
     position: relative;
@@ -49,7 +47,6 @@ const StyledInputContainer = styled.div<{disabled : boolean, isError : boolean, 
 `;
 
 const StyledDescription = styled.p`
-    ${resetCss}
     ${TYPOGRAPHY.p2}
     color: ${PALETTE.blackStrong};
     margin-top: 0.5rem;
@@ -69,7 +66,6 @@ interface I_InputContainerProps{
 }
 
 export const StyledLabel = styled.label<{disabled : boolean}>`
-    ${resetCss}
     ${TYPOGRAPHY.p2}
     color: ${ props => props.disabled ? PALETTE.blackMedium : PALETTE.blackStrong};
     height: 1.25rem;

--- a/components/InputTags.tsx
+++ b/components/InputTags.tsx
@@ -3,14 +3,13 @@ import styled, {css} from 'styled-components';
 import { PALETTE, TYPOGRAPHY } from './Theme';
 import Tag, {TagColor, TagSize} from './Tag';
 import InputContainer, {StyledLabel} from './InputContainer';
-import { visuallyHidden, resetCss } from './utils';
+import { visuallyHidden } from './utils';
 
 const INPUT_MIN_WIDTH = "3rem";
 const TAG_CONTAINER_GAP = "0.25rem";
 const TAG_CONTAINER_MAX_WIDTH = `calc(100% - ${INPUT_MIN_WIDTH} - ${TAG_CONTAINER_GAP})`;
 
 const StyledLayout = styled.div`
-    box-sizing: border-box;
     display: flex;
     gap: 0.2rem;
     padding: 0.9rem;
@@ -19,7 +18,6 @@ const StyledLayout = styled.div`
 
 const StyledTagContainer = styled.div<{hasOverflow : boolean, readOnly : boolean}>`
     align-items: center;
-    box-sizing: border-box;
     display: flex;
     gap: ${TAG_CONTAINER_GAP};
     max-width: ${props => props.readOnly ? "100%" : TAG_CONTAINER_MAX_WIDTH};
@@ -58,13 +56,12 @@ const StyledTagContainer = styled.div<{hasOverflow : boolean, readOnly : boolean
 
 
 const StyledTagInput = styled.input.attrs({ type: "text" })`
-    ${resetCss}
     ${TYPOGRAPHY.p2}
 
     background: transparent;
-    box-sizing: border-box;
     height: 1.75rem;
     min-width: ${INPUT_MIN_WIDTH};
+    outline: none;
     width: 100%;
 
     &::placeholder{

--- a/components/InputText.tsx
+++ b/components/InputText.tsx
@@ -22,11 +22,7 @@ const StyledTextInput = styled.input.attrs({ type: "text" })`
         background: transparent;
         color: ${PALETTE.blackA24};
     }
-
-    &:focus-visible{
-        outline: none;
-    }
-
+    
     &:-webkit-autofill,
     &:-webkit-autofill:hover, 
     &:-webkit-autofill:focus {

--- a/components/InputText.tsx
+++ b/components/InputText.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
 import styled from 'styled-components';
 import { PALETTE, TYPOGRAPHY } from './Theme';
-import {resetCss} from './utils';
 import InputContainer, {StyledLabel} from './InputContainer';
 import Icon from './Icons';
 import { IconMediumId } from './IconsMedium';
 
 const StyledTextInput = styled.input.attrs({ type: "text" })`
-    ${resetCss}
     ${TYPOGRAPHY.p2}
 
     background: transparent;
-    box-sizing: border-box;
     height: 100%;
+    outline: none;
     padding: 1.5rem 1rem 0.3rem 1rem;
     width: 100%;
     
@@ -23,6 +21,10 @@ const StyledTextInput = styled.input.attrs({ type: "text" })`
     &:disabled{
         background: transparent;
         color: ${PALETTE.blackA24};
+    }
+
+    &:focus-visible{
+        outline: none;
     }
 
     &:-webkit-autofill,

--- a/components/Island.tsx
+++ b/components/Island.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import styled, { ThemeProvider } from 'styled-components';
 import { PALETTE, TYPOGRAPHY } from './Theme';
 import Badge, {BadgeType} from './Badge';
-import { resetCss } from './utils';
 import ButtonLabel from './ButtonLabel';
 import { ButtonColorMode, ButtonType } from './Button';
 import SubjectIcon, {Subject} from './IconMediumSubject';
@@ -52,7 +51,6 @@ const StyledProgressBar = styled.div<Pick<I_IslandProps, "progress">>`
 `;
 
 const StyledProgressText = styled.p`
-    ${resetCss}
     ${TYPOGRAPHY.p3};
     color: ${PALETTE.white};
 `;
@@ -74,7 +72,6 @@ const StyledSubjectContainer = styled.div`
 `;
 
 const StyledLayout = styled.div`
-    box-sizing: border-box;
     display: grid;
     gap: ${props => props.theme.layoutGap};
     grid-template-areas: 
@@ -90,14 +87,12 @@ const StyledLayout = styled.div`
 `;
 
 const StyledHead = styled.h6`
-    ${resetCss}
     ${TYPOGRAPHY.h6}
     color: ${PALETTE.white};
     grid-area: heading;
 `;
 
 const StyledDescription = styled.p`
-    ${resetCss}
     ${TYPOGRAPHY.p2}
     color: ${PALETTE.whiteStrong};
     grid-area: desc;

--- a/components/Notification.tsx
+++ b/components/Notification.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 import { PALETTE, TYPOGRAPHY, SHADOW } from './Theme';
 import CircleContainer from './CircleAroundIcon';
-import {resetCss} from './utils';
 import Button from './ButtonLabel';
 import {ButtonType, ButtonColorMode} from './Button';
 import Icon from './Icons';
@@ -18,7 +17,6 @@ const StyledLayout = styled.div<{hasAll : boolean}>`
         "text icon"
         "buttons buttons";
     gap: ${props => props.hasAll ? "1.25rem" : "0"};
-    box-sizing: border-box;
 
     @media (max-width: ${BREAKPOINT_MOBILE}) {
         display: grid;
@@ -39,14 +37,12 @@ const StyledButtonsContainer = styled.div`
 `;
 
 const StyledDescription = styled.p`
-    ${resetCss}
     ${TYPOGRAPHY.p2}
     align-items: center;
     display: flex;
 `;
 
 const StyledHeading = styled.h3`
-    ${resetCss}
     ${TYPOGRAPHY.p1}
     font-weight: bold;
 `;
@@ -62,14 +58,13 @@ const StyledIconContainer = styled.div<{fillColor : PALETTE}>`
 const StyledNotification = styled.div`
     background: white;
     border-radius: 0.5rem;
+    box-shadow: ${SHADOW.default};
+    left: 0.4375rem;
+    max-width: calc(100vw - (0.4375rem * 2));
     padding: 1.25rem;
     position: fixed;
     top: 0.4375rem;
-    left: 0.4375rem;
-    box-shadow: ${SHADOW.default};
-    box-sizing: border-box;
     width: 24.625rem;
-    max-width: calc(100vw - (0.4375rem * 2));
     z-index: 999;
 
     @media (max-width: ${BREAKPOINT_MOBILE}){

--- a/components/Paragraph.tsx
+++ b/components/Paragraph.tsx
@@ -34,14 +34,6 @@ const themePicker = (size : number | undefined) : any => {
     }
 }
 
-const resetP = css`
-    margin: 0;
-    padding: 0;
-    border: 0;
-    font-size: 100%;
-    font: inherit;
-    vertical-align: baseline;
-`;
 
 interface StyledParagraphProps{
     color?: string,
@@ -50,8 +42,6 @@ interface StyledParagraphProps{
 }
 
 const StyledParagraph = styled.p`
-    ${ resetP }
-
     ${
         (props : StyledParagraphProps) => {
             switch(props.pSize){

--- a/components/PopUp.tsx
+++ b/components/PopUp.tsx
@@ -9,7 +9,6 @@ const StyledPopUp = styled.section<{height : string}>`
     background: ${PALETTE.white};
     border-radius: 0.5rem;
     box-shadow: ${SHADOW.default};
-    box-sizing: border-box;
     left: calc(50% - (30.0625rem / 2));
     padding: 1.8125rem 1rem;
     position: fixed;

--- a/components/PopUpPreset.tsx
+++ b/components/PopUpPreset.tsx
@@ -6,7 +6,6 @@ import { PALETTE, TYPOGRAPHY } from './Theme';
 import ButtonLabel from './ButtonLabel';
 import { ButtonColorMode, ButtonType } from './Button';
 import CircleAroundIcon from './CircleAroundIcon';
-import {resetCss} from './utils';
 
 export const enum PopUpPresetMode{
     success = "success",
@@ -81,13 +80,11 @@ const StyledLayout = styled.div`
 `;  
 
 const StyledHeading = styled.h4`
-    ${resetCss}
     ${TYPOGRAPHY.h4}
     padding-top: .8rem;
 `;
 
 const StyledDescription = styled.p`
-    ${resetCss}
     ${TYPOGRAPHY.p2}
 `;
 

--- a/components/Tag.tsx
+++ b/components/Tag.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled, { css, ThemeProvider } from 'styled-components';
 import { PALETTE, SHADOW, ICON_SIZES, TYPOGRAPHY, LAYOUT } from './Theme';
-import {resetCss} from './utils';
 import Icon from './Icons';
 import { IconSmallId } from './IconsSmall';
 import customCursorImg from '../public/cursorHand.svg';
@@ -12,7 +11,6 @@ const StyledTag = styled.div<{ size : TagSize, disabled : boolean, hasOnClick : 
     border: 1px solid ${ props => props.disabled && props.theme.disabledBackground !== undefined ? props.theme.disabledBackground : props.theme.border};
     border-radius: ${ LAYOUT.borderRadius };
     box-shadow: ${ props => props.theme.shadow === undefined ? "none" : props.theme.shadow };
-    box-sizing: border-box;
     color: ${ props => props.theme.text };
     display: flex;
     gap: 0.275rem;
@@ -54,7 +52,6 @@ const StyledTag = styled.div<{ size : TagSize, disabled : boolean, hasOnClick : 
 `;
 
 const StyledButton = styled.button`
-    ${resetCss}
     background: transparent;
     height: ${ICON_SIZES.small};
     position: relative;

--- a/components/utils.tsx
+++ b/components/utils.tsx
@@ -6,18 +6,6 @@ export function isBlank(prop : any) : boolean{
 }
 
 
-export const resetCss = css`
-    margin: 0;
-    padding: 0;
-    border: 0;
-    outline: 0;
-    font-weight: inherit;
-    font-style: inherit;
-    font-size: 100%;
-    font-family: inherit;
-    vertical-align: baseline;
-`;
-
 export const visuallyHidden = css`
     clip: rect(0 0 0 0);
     clip-path: inset(50%);


### PR DESCRIPTION
Reset CSS sheet now applied via importing into preview.js instead of individually importing it into components.
New reset sheet expanded to apply "box-sizing: border-box;" to everything, so went through removing those.
Removed some commented-out bits.