### PR TITLE
Add Toggle and stories. Update Paragraph to accept className.

### DIFF
--- a/components/Paragraph.tsx
+++ b/components/Paragraph.tsx
@@ -2,12 +2,6 @@ import React from 'react';
 import styled, { css, ThemeProvider } from 'styled-components';
 import { PALETTE, TYPOGRAPHY } from './Theme';
 
-interface ParagraphProps{
-    color?: string,
-    size?: 1 | 2 | 3,
-    bold?: boolean,
-    children?: React.ReactNode;
-}
 
 const p1Theme = {
     boldWeight: "700"
@@ -34,19 +28,20 @@ const themePicker = (size : number | undefined) : any => {
     }
 }
 
-
 interface StyledParagraphProps{
     color?: string,
     bold: boolean,
-    pSize: number
+    pSize: number,
 }
 
-const StyledParagraph = styled.p`
+const StyledParagraph = styled.p<StyledParagraphProps>`
     ${
-        (props : StyledParagraphProps) => {
+        (props) => {
             switch(props.pSize){
                 case 1:
                     return TYPOGRAPHY.p1;
+                case 2:
+                    return TYPOGRAPHY.p2;
                 case 3:
                     return TYPOGRAPHY.p3;
                 default:
@@ -56,17 +51,27 @@ const StyledParagraph = styled.p`
     }
 
     color: ${ props => props.color || PALETTE.black };
-    font-weight: ${ (props : any) => props.bold ? props.theme.fontWeight : "400" };
+    font-weight: ${ props => props.bold ? props.theme.fontWeight : "400" };
     width: fit-content;
 `;
 
 
-export default function Paragraph({color, size, bold, children} : ParagraphProps){
+interface ParagraphProps{
+    color?: string,
+    size?: 1 | 2 | 3,
+    bold?: boolean,
+    className? : string,
+    children?: React.ReactNode,
+}
+
+export default function Paragraph({color, size, className, bold, children} : ParagraphProps){
     const theme = themePicker(size);
     return <ThemeProvider theme={theme}>
             <StyledParagraph    color = {color}
                                 bold = { bold || false } 
-                                pSize = { size || 2 }>
+                                pSize = { size || 2 } 
+                                className = {className}
+                                >
                 {children}
             </StyledParagraph>
         </ThemeProvider>

--- a/components/Toggle.stories.tsx
+++ b/components/Toggle.stories.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import Toggle from './Toggle';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+export default {
+    title: 'UI Kit/Input/Toggle',
+    component: Toggle,
+    args: {
+        onScreenReader: "toggle"
+    }
+  } as ComponentMeta<typeof Toggle>;
+
+const Template: ComponentStory<typeof Toggle> = args => {
+    let [isPressed, setIsPressed] = React.useState(args.isOn ?? false);
+
+    const onClick = () => {
+        setIsPressed(prevState => {
+            return !prevState
+        });
+    };
+
+    return <Toggle  {...args}
+                    isOn = {isPressed}
+                    parentOnClick={onClick} />}
+;
+
+export const Off = Template.bind({});
+
+export const OffHover = Template.bind({});
+OffHover.parameters = {
+    pseudo: {hover: true}
+}
+
+export const OffDisabled = Template.bind({});
+OffDisabled.args = {
+    disabled: true
+}
+
+export const OffFocus = Template.bind({});
+OffFocus.parameters = {
+    pseudo: {focus: true}
+}
+
+export const On = Template.bind({});
+On.args = {
+    isOn: true
+}
+
+export const OnHover = Template.bind({});
+OnHover.args = {
+    ...On.args
+}
+OnHover.parameters = {
+    pseudo: {hover: true}
+}
+
+export const OnDisabled = Template.bind({});
+OnDisabled.args = {
+    ...On.args,
+    disabled: true
+}
+
+export const OnFocus = Template.bind({});
+OnFocus.args = {
+    ...On.args
+}
+OnFocus.parameters = {
+    pseudo: {focus: true}
+}
+
+// ----------------------------------
+const LABEL = {
+    heading: "Заголовок",
+    description: "Описание в несколько строк",
+    onScreenReader : "toggle",
+}
+
+export const OffWithLabel = Template.bind({});
+OffWithLabel.args = {
+    ...Off.args,
+    label: LABEL
+}
+
+export const OnWithLabel = Template.bind({});
+OnWithLabel.args = {
+    ...On.args,
+    label: LABEL
+}

--- a/components/Toggle.tsx
+++ b/components/Toggle.tsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import styled from 'styled-components';
+import { PALETTE, FONT } from './Theme';
+import Icon from './Icons';
+import { IconSmallId } from './IconsSmall';
+import Paragraph from './Paragraph';
+import { visuallyHidden, getClassName } from './utils';
+
+const StyledToggleBase = styled.button<{hasLabel : boolean}>`
+    align-items: center;
+    border-width: 0.125rem;
+    border-style: solid;
+    border-radius: 1.5rem;
+    display: flex;
+    ${props => props.hasLabel ? "grid-area: toggle;" : "" }
+    height: 1.5rem;
+    justify-content: space-between;
+    padding: 0.125rem;
+    width: 3rem;
+    
+    &:disabled{
+        opacity: 56%;
+    }
+
+    &:focus:not([disabled]){
+        border-color: ${PALETTE.blackStrong};
+    }
+
+    svg path{
+        fill: ${PALETTE.white};
+    }
+
+    &:after{
+        aspect-ratio: 1/1;
+        border-radius: 100%;
+        content: '';
+        display: block;  
+    }
+`;
+
+const StyledToggleOn = styled(StyledToggleBase)`
+    background: ${PALETTE.primary};
+    border-color: ${PALETTE.primary};
+
+    &:after{
+        background: ${PALETTE.white};
+        height: 1rem;
+    }
+
+    &:hover:not([disabled]){
+        background: ${PALETTE.hover};
+        border-color: ${PALETTE.hover};
+    }
+`;
+
+const StyledToggleOff = styled(StyledToggleBase)`
+    background: ${PALETTE.white};
+    border-color: ${PALETTE.disabled};
+
+    &:before{
+        aspect-ratio: 1/1;
+        background: ${PALETTE.primary};
+        border-radius: 100%;
+        content: '';
+        display: block;
+        height: 1rem;
+    }
+
+    &:after{
+        background: transparent;
+        border: 0.125rem solid ${PALETTE.disabled};
+        height: 0.75rem;
+        margin-right: 0.25rem;
+        opacity: 56%;
+    }
+
+    &:hover:not([disabled]){
+        &:before{
+            background: ${PALETTE.hover};
+        }
+        &:after{
+            border-color: #BBACE2;
+        }
+    }
+`;
+
+
+const StyledLayout = styled.div`
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto auto;
+    grid-template-areas: 
+        "toggle heading"
+        "toggle description"
+    ;
+    gap: 0.125rem 0.75rem;
+`;
+
+// Non-standard heading style
+const StyledHeading = styled.h3`
+    font-family: ${FONT.main};
+    font-size: 1rem;
+    font-weight: normal;
+    grid-area: heading;
+    line-height: 1.5rem; 
+`;
+
+const StyledParagraph = styled(Paragraph)`
+    grid-area: description;
+`;
+
+const StyledScreenReaderName = styled.span`
+    ${visuallyHidden}
+`;
+
+interface I_ToggleProps{
+    disabled : boolean,
+    isOn : boolean,
+    label? : LabelProps,
+    onScreenReader : string,
+    parentOnClick: () => void,
+}
+
+type LabelProps = {
+    heading : string,
+    description : string,
+}
+
+export default function Toggle({ disabled, isOn, label, onScreenReader, parentOnClick} : I_ToggleProps){  
+    const toggle = <ToggleButton    disabled={disabled} 
+                                    label={label}
+                                    isOn={isOn}
+                                    onScreenReader={onScreenReader}
+                                    parentOnClick={parentOnClick}
+                                    />
+
+    if(label === undefined){
+        return toggle;
+    }
+    return  <LabelWrapper label={label}>
+                {toggle}
+            </LabelWrapper>
+}
+
+function ToggleButton({disabled, isOn, label, onScreenReader, parentOnClick} : I_ToggleProps) {
+
+    const StyledToggleCurrent = isOn ? StyledToggleOn : StyledToggleOff;
+
+    return  <StyledToggleCurrent    aria-pressed={isOn}
+                                    onClick={parentOnClick}
+                                    disabled={disabled}
+                                    hasLabel={label === undefined}
+                                    >
+                <StyledScreenReaderName>
+                    {onScreenReader}
+                </StyledScreenReaderName>
+                { isOn &&
+                    <Icon idSmall={IconSmallId.check} />
+                }
+            </StyledToggleCurrent>
+}
+
+type LabelWrapperProps = {
+    label : LabelProps,
+    children : React.ReactNode,
+}
+
+function LabelWrapper({label, children} : LabelWrapperProps){
+    return <StyledLayout>
+                {children}
+                <StyledHeading>
+                    {label.heading}
+                </StyledHeading>
+                <StyledParagraph size={3} color={PALETTE.blackStrong} className={getClassName(StyledParagraph)}>
+                    {label.description}
+                </StyledParagraph>
+            </StyledLayout>
+}

--- a/components/utils.tsx
+++ b/components/utils.tsx
@@ -29,3 +29,9 @@ export function debounce(func : CallbackFunctionVariadicAnyReturn, timeout = 300
         timer = setTimeout(() => { func.apply(this, args); }, timeout);
     };
 }
+
+export function getClassName(styledComponent : any){
+    const className = String(styledComponent).replace(".", "");
+    console.log(className);
+    return className;
+}


### PR DESCRIPTION
In Toggle's so-called "label" it uses Paragraph formatting for the description but to get the Paragraph in the right place it was necessary to add a grid-area line to the CSS. To support this, className has been added to Paragraph's props.

Added getClassName to utils, so there's a means of finding the styled-components className in order to pass it to Paragraph.