### PR TITLE
Add Select and stories, plus Search renaming/refactoring

### DIFF
--- a/components/ContextMenuLi.tsx
+++ b/components/ContextMenuLi.tsx
@@ -24,13 +24,13 @@ const StyledMenuLi = styled.li`
 `;
 export interface MenuItemProps{
     display: string,
-    handleClick : () => void,
+    handleClick : (e : React.MouseEvent<HTMLLIElement>) => void,
     selected? : boolean  
 }
 
 export default function MenuLi({ display, selected, handleClick } : MenuItemProps){
     return (
-        <StyledMenuLi onClick={ () => handleClick() }>
+        <StyledMenuLi onClick={ (e) => handleClick(e) }>
             {display}
             {selected &&
                 <Icon idMedium={IconMediumId.check} />

--- a/components/ContextMenuLi.tsx
+++ b/components/ContextMenuLi.tsx
@@ -7,16 +7,13 @@ import { IconMediumId } from './IconsMedium';
 
 export const StyledMenuLi = styled.li`
     ${ TYPOGRAPHY.p2 }
-
     background: ${PALETTE.white};
     display: flex;
     justify-content: space-between;
     padding: 0.5rem 0.75rem 0.5rem 1rem;
-
     svg path{
         fill: ${PALETTE.black};
     }
-
     &:hover{
         cursor: url(${customCursorImg}), auto;
         background: ${PALETTE.grayL};
@@ -24,13 +21,13 @@ export const StyledMenuLi = styled.li`
 `;
 export interface MenuItemProps{
     display: string,
-    handleClick : (e : React.MouseEvent<HTMLLIElement>) => void,
+    handleClick : () => void,
     selected? : boolean  
 }
 
 export default function MenuLi({ display, selected, handleClick } : MenuItemProps){
     return (
-        <StyledMenuLi onClick={ (e) => handleClick(e) }>
+        <StyledMenuLi onClick={ () => handleClick() }>
             {display}
             {selected &&
                 <Icon idMedium={IconMediumId.check} />
@@ -38,4 +35,3 @@ export default function MenuLi({ display, selected, handleClick } : MenuItemProp
         </StyledMenuLi>
     )
 }
-

--- a/components/Search.stories.tsx
+++ b/components/Search.stories.tsx
@@ -8,30 +8,30 @@ export default {
     component: Search,
     args: {
         handleSubmit: () => console.log("Form submitted"),
-        updateResults: (str : string) => console.log(`Update results for search term ${str}`),
+        updateOptions: (str : string) => console.log(`Update results for search term ${str}`),
     }
   } as ComponentMeta<typeof Search>;
 
 const Template: ComponentStory<typeof Search> = args => <Search {...args} />;
 
 const FunctioningTemplate: ComponentStory<typeof Search> = args => {
-    const [results, setResults] = React.useState<string[] | null>(null);
+    const [options, setOptions] = React.useState<string[] | null>(null);
 
-    function updateResults(newInput : string | null){
+    function updateOptions(newInput : string | null){
         if(newInput === null || newInput === ""){
-            setResults(null);
+            setOptions(null);
         }
         else if(newInput === "R"){
-            setResults([]);
+            setOptions([]);
         }
         else if(newInput === "Rus"){
-            setResults([
+            setOptions([
                 "Russia",
                 "Rusk"
             ]);
         }
         else{
-            setResults([
+            setOptions([
                 newInput + "-a-like",
                 newInput + "-ish",
             ]);
@@ -47,9 +47,9 @@ const FunctioningTemplate: ComponentStory<typeof Search> = args => {
     }
 
     return <Search  {...args}
-                    updateResults={updateResults}
+                    updateOptions={updateOptions}
                     handleSubmit={onSubmit}
-                    results={results}
+                    options={options}
                     />;
 };
 
@@ -63,17 +63,17 @@ Hover.parameters = {
 
 export const Loading = Template.bind({});
 Loading.args = {
-    displayResults: true,
+    showOptions: true,
     initialValue: "Rus",
     loading: true
 }
 
 export const ActiveResults = Template.bind({});
 ActiveResults.args = {
-    displayResults: true,
+    showOptions: true,
     loading: false,
     initialValue: "Rus",
-    results: [
+    options: [
         "Russia",
         "Rusk"
     ]
@@ -81,15 +81,15 @@ ActiveResults.args = {
 
 export const NoResults = Template.bind({});
 NoResults.args = {
-    displayResults: true,
+    showOptions: true,
     loading: false,
     initialValue: "R",
-    results: []
+    options: []
 }
 
 export const Filled = Template.bind({});
 Filled.args = {
     initialValue: "Russia",
-    displayResults: false
+    showOptions: false
 }
 

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -5,6 +5,7 @@ import Icon from './Icons';
 import { IconMediumId } from './IconsMedium';
 import customCursorImg from '../public/cursorHand.svg';
 import { StyledScreenReaderOnly } from './utils';
+import { moveWithinMenu } from './utils';
 
 const StyledSearchAndResultsContainer = styled.div`
     position: relative;
@@ -219,7 +220,7 @@ export default function Search({initialValue, disabled, updateOptions : updateRe
 
         if(e.key === 'ArrowDown' || e.key === 'ArrowUp'){
             e.preventDefault(); /* Prevent the cursor from moving to the start or end of the text when navigating the results */
-            moveWithinMenu(e);
+            moveWithinMenu(e, options, activeId, setActiveId);
         }
 
         if(e.key === 'Enter'){
@@ -236,35 +237,6 @@ export default function Search({initialValue, disabled, updateOptions : updateRe
             setActiveId(null);
         }
     }
-
-    function moveWithinMenu(e: React.KeyboardEvent<HTMLDivElement>){
-        if(options === null || options === undefined){
-            return;
-        }
-
-        let newId = activeId;
-
-        if(e.key === 'ArrowUp'){
-            if(newId === null || newId <= 0 ){ /* Loop from top to bottom */
-                newId = options.length - 1;
-            }
-            else{
-                newId = newId - 1;
-            }
-        }
-        
-        if(e.key === 'ArrowDown'){
-            if(newId === null || newId >= options.length - 1 ){ /* Loop from bottom to top */
-                newId = 0;
-            }
-            else{
-                newId = newId + 1;
-            }
-        }
-
-        setActiveId(newId);
-    }
-
 
     const hasInput = input !== null;
     const inputId = React.useId();

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -171,7 +171,7 @@ interface I_SearchProps{
 
 type SearchResultData = string;
 
-export default function Search({initialValue, disabled, updateOptions : updateResults, handleSubmit, loading, options, showOptions : showOptionsOnLoad} : I_SearchProps){
+export default function Search({initialValue, disabled, updateOptions, handleSubmit, loading, options, showOptions : showOptionsOnLoad} : I_SearchProps){
     const [input, setInput] = React.useState<string | null>(initialValue ?? null);
     const [showOptions, setShowOptions] = React.useState<boolean>(showOptionsOnLoad === undefined ? false : showOptionsOnLoad);
     const [activeId, setActiveId] = React.useState<number | null>(null);
@@ -187,7 +187,7 @@ export default function Search({initialValue, disabled, updateOptions : updateRe
 
         if(e.target.value !== null || e.target.value !== ""){
             setShowOptions(true);
-            updateResults(e.target.value);
+            updateOptions(e.target.value);
         }
         else {
             setShowOptions(false);
@@ -220,7 +220,7 @@ export default function Search({initialValue, disabled, updateOptions : updateRe
 
         if(e.key === 'ArrowDown' || e.key === 'ArrowUp'){
             e.preventDefault(); /* Prevent the cursor from moving to the start or end of the text when navigating the results */
-            moveWithinMenu(e, options, activeId, setActiveId);
+            moveWithinMenu({e, options, activeId, setActiveId});
         }
 
         if(e.key === 'Enter'){

--- a/components/Select.stories.tsx
+++ b/components/Select.stories.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import Select from './Select';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+export default {
+    title: 'UI Kit/Select',
+    component: Select,
+    args: {
+      id: "id_countrySelect",
+      label: "Your country",
+      options: ["Russia", "USA", "Germany"],
+      placeholder: "Example, Russia",
+      selectedOption: null,
+  }
+
+  } as ComponentMeta<typeof Select>;
+
+const Template: ComponentStory<typeof Select> = args => <Select {...args} />;
+
+const ControlledTemplate : ComponentStory<typeof Select> = args => {
+  const [selected, setSelected] = React.useState<string | null>(args.selectedOption ?? null);
+
+  function selectOption(data : string | null){
+    setSelected(data);
+  }
+
+  return <Select {...args} 
+            selectedOption = {selected}
+            setSelectedOption = {selectOption}
+          />;
+};
+export const Default = ControlledTemplate.bind({});
+
+export const Hover = Template.bind({});
+Hover.parameters = {
+  pseudo: {hover: true}
+}
+
+export const ActiveFocus = Template.bind({});
+ActiveFocus.args = {
+  showOptions: true
+}
+
+export const FilledOpen = Template.bind({});
+FilledOpen.args = {
+  showOptions: true,
+  selectedOption: "USA",
+}
+
+export const FilledClosed = Template.bind({});
+FilledClosed.args = {
+  showOptions: false,
+  selectedOption: "USA",
+}
+
+const Longistan = "Democratic Amazing Joy Republic of North-West VeryVeryLongLongLongBlahBlahBlahistan";
+export const LongOption = Template.bind({});
+LongOption.args = {
+  showOptions: true,
+  selectedOption: Longistan,
+  options: ["Russia", "USA", "Germany", Longistan]
+}
+
+
+

--- a/components/Select.tsx
+++ b/components/Select.tsx
@@ -1,0 +1,479 @@
+import React from 'react';
+import styled, {css} from 'styled-components';
+import { PALETTE, TYPOGRAPHY, LAYOUT, SHADOW } from './Theme';
+import { StyledLabel } from './InputContainer';
+import Icon from './Icons';
+import { IconMediumId } from './IconsMedium';
+import customCursorImg from '../public/cursorHand.svg';
+import { StyledScreenReaderOnly } from './utils';
+import { moveWithinMenu } from './utils';
+
+const StyledInputAndOptionsContainer = styled.div`
+    width: fit-content;
+`;
+
+const StyledInputContainer = styled.div<{disabled : boolean, showOptions : boolean, inputFocused : boolean}>`
+    background: ${PALETTE.white};
+    box-shadow: ${props => props.showOptions && !props.disabled ? SHADOW.hoverFile : SHADOW.default};
+    border-radius: ${LAYOUT.borderRadius};
+    height: 3.5rem;
+    max-width: 100%;
+    overflow: hidden;
+    position: relative;
+    width: 30.125rem;
+
+    ${ props => {
+        if(props.disabled){
+            return;
+        }
+        return css`   
+            &:hover {
+                box-shadow: ${SHADOW.hover};
+            }
+        `;
+    }}
+
+    /*  
+        Design exists for "Focus Active" (no outline around container, options displayed), but 
+        not "Focus Inactive".
+        For accessibility, add an outline for Focus Inactive. overflow: hidden has disabled the
+        normal outline, so make a fake one using a pseudo element.
+    */
+    ${ props => {
+        if(!props.inputFocused || props.showOptions) {
+            return;
+        }
+
+        return css`
+            &:before{
+                border: 0.125rem solid ${PALETTE.blackStrong};
+                border-radius: ${LAYOUT.borderRadius};
+                content: '';
+                display: block;
+                height: 100%;
+                left: 0;
+                position: absolute;
+                top: 0;
+                width: 100%;
+                z-index: 2;  
+            }
+        `;
+    }}
+`;
+
+const StyledInputBarLayout = styled.div`
+    display: grid;
+    gap: 0 0.25rem;
+    grid-template-areas: "selection closeIcon toggleIcon";
+    grid-template-columns: 1fr 1.5rem 1.5rem;
+    grid-template-rows: 1fr;
+    height: 100%;
+    padding: 0 0.75rem;
+    width: 100%;
+`;
+
+const StyledSelectedInput = styled.div`
+    ${TYPOGRAPHY.p2}
+    background: transparent;
+    color: ${PALETTE.black};
+    grid-area: selection;
+    outline: none;
+    overflow: hidden;
+    padding: 1.5rem 0 0.3rem 0.25rem;
+    text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: 100%;
+`;
+
+const StyledPlaceholderSpan = styled.span`
+    color: ${PALETTE.blackStrong};
+`;
+
+const StyledCloseButton = styled.button`
+    background: transparent;
+    grid-area: closeIcon;
+    
+    svg path{
+        fill: ${ PALETTE.blackStrong };
+    }
+
+    &:hover{
+        cursor: url(${customCursorImg}), auto;
+
+        svg path{
+            fill: ${ PALETTE.black };
+        }
+    }
+`;
+
+const StyledToggleButton = styled.button<{isActive : boolean}>`
+    background: transparent;
+    grid-area: toggleIcon;
+
+    svg path{
+        fill: ${ props => props.isActive ? PALETTE.black : PALETTE.blackStrong };
+    }
+
+    &:hover{
+        cursor: url(${customCursorImg}), auto;
+    }
+`;
+
+const StyledOptionsContainer = styled.div`
+    align-items: stretch;
+    background: ${PALETTE.white};
+    border-radius: ${LAYOUT.borderRadius};
+    box-shadow: ${SHADOW.contextMenu};
+    display: flex;
+    flex-direction: column;
+    margin: 0.25rem 0 0 0;
+    max-width: 100%;
+    overflow: hidden;
+    padding: 0.5rem 0 0.4375rem 0;
+    position: relative;
+    width: 30.125rem;  
+    z-index: 3;
+`;
+
+const StyledOption = styled.div<{isHighlighted : boolean}>`
+    ${TYPOGRAPHY.p2}
+    align-text: left;
+    background: ${props => props.isHighlighted ? PALETTE.grayL : "transparent"};
+    color: ${PALETTE.black};
+    padding: 0.5rem 0.75rem 0.5rem 1rem;
+    position: relative;
+
+    &:hover{
+        background: ${PALETTE.grayL};
+        cursor: url(${customCursorImg}), auto;
+    }
+
+    span{
+        display: block;
+        max-width: calc(100% - 1.5rem - 0.4rem);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    svg{
+        position: absolute;
+        top: calc(50% - (1.5rem / 2));
+        right: 12px;
+    }
+`;
+
+const StyledFloatingLabel = styled(StyledLabel)<{floatUp : boolean}>`
+    top: calc(50% - (1.25rem / 2) - 0.125rem);
+    transition: 0.2s ease all;
+
+    ${props => {
+        if(props.floatUp){
+            return css`
+                ${TYPOGRAPHY.p3}
+                left: 1rem;
+                opacity: 1;
+                top: 0.375rem;
+            `;
+        }
+    }}
+`;
+
+interface I_SelectProps{
+    disabled? : boolean,
+    id?: string,
+    label: string,
+    options: OptionData[],
+    placeholder: string,
+    selectedOption: OptionData | null,
+    setSelectedOption: (data : OptionData | null) => void,
+    showOptions? : boolean,
+}
+type OptionData = string;
+
+export default function Select({disabled, id, label, options, placeholder, selectedOption, setSelectedOption, showOptions : optionsVisibleOnInit} : I_SelectProps){
+    const [optionsVisible, setOptionsVisible] = React.useState<boolean>(optionsVisibleOnInit ?? false);
+    const [activeId, setActiveId] = React.useState<number | null>(null);
+    const [selectedDisplayStr, setSelectedDisplayStr] = React.useState<string | null>(null);
+    const [inputHasFocus, setInputHasFocus] = React.useState(false);
+
+    // If an option is selected before the listbox receives focus, focus is set on the selected option.
+    React.useEffect(() => {
+        if(selectedOption === null){
+            return;
+        }
+        const index = options.findIndex((ele) => ele === selectedOption);
+        if(index === -1){
+            return;
+        }
+
+        setActiveId(index);
+    }, [selectedOption, options])
+
+    // Enable "click outside to close options list"
+    const containerRef = React.useRef(null);
+    React.useEffect(() => {
+        if(optionsVisible){
+            window.addEventListener('click', clickOutsideToClose);
+        }
+        else{
+            window.removeEventListener('click', clickOutsideToClose);
+        }
+
+        return function cleanup(){
+            window.removeEventListener('click', clickOutsideToClose);
+        }
+
+        function clickOutsideToClose(e : MouseEvent){
+            // Prevent the menu from closing prematurely when the user toggles an option
+            if(clickedInside(e, containerRef)){
+                return;
+            }
+            setOptionsVisible(false);
+        }
+
+        function clickedInside(e : MouseEvent, ref : React.MutableRefObject<null>){
+            return ref.current && e.composedPath().includes(ref.current);
+        }
+
+    }, [optionsVisible]);
+
+
+    // Manage text displayed in the "selected" area
+    React.useEffect(() => {
+        // Empty and closed = label only
+        if(!optionsVisible && selectedOption === null){
+            setSelectedDisplayStr(null);
+        }
+        // Empty and open = placeholder-like text. Use the displayStr for the black line at the start,
+        // remaining placeholder-like text to be in a separate element
+        else if(optionsVisible && selectedOption === null){
+            setSelectedDisplayStr("|");
+        }
+        // Filled = show the selection
+        else{
+            setSelectedDisplayStr(selectedOption);
+        }
+    }, [selectedOption, optionsVisible]);
+
+
+    // Buttons in the "input" area
+    function handleFocus(){
+        setInputHasFocus(true);
+        setOptionsVisible(true);
+        if(activeId === null && selectedOption === null){
+            setActiveId(0);
+        }
+    }
+
+    function handleBlur(){
+        setInputHasFocus(false);
+    }
+
+    function toggleOptionVisibility(){
+        // If none of the variables have any better ideas, highlight the first option for keyboard users
+        if(activeId === null && selectedOption === null && !optionsVisible){
+            setActiveId(0);
+        }
+
+        setOptionsVisible(prevState => {
+            return !prevState;
+        });
+    }
+
+    function clearInput(){
+        setSelectedOption(null);
+    }
+
+    // Support for picking a suggestion from the options list
+    function onOptionPick(data : OptionData){
+        setSelectedOption(data);
+    }
+
+    function onKeyDown(e : React.KeyboardEvent<HTMLDivElement>){
+        if(e.key === 'ArrowDown' || e.key === 'ArrowUp'){
+            e.preventDefault(); /* Prevent the cursor from moving to the start or end of the text when navigating the results */
+            if(!optionsVisible){
+                setOptionsVisible(true);
+            }
+            moveWithinMenu({e, options, activeId, setActiveId});
+        }
+
+        if(e.key === 'Enter' || e.key === 'Space'){
+            if(activeId !== null){
+                if(options !== null && options !== undefined && options.length > 0){
+                    onOptionPick(options[activeId]);
+                }
+            }
+        }
+
+        if(e.key === 'Escape'){
+            setOptionsVisible(false);
+        }
+    }
+
+    let inputId = React.useId();
+    inputId = id ?? inputId;
+    const optionsListId = inputId + "_optionList";
+    const optionIdPrefix = optionsListId + "-";
+    const hasSelection = selectedOption !== null;
+
+    const optionsListInteractivity = {
+        activeId,
+        optionIdPrefix,
+        onOptionPick,
+        selectedOption,
+    }
+
+    const selectInputProps = {
+        activeDescendantId: activeId === null ? undefined : optionIdPrefix + activeId,
+        inputId,
+        optionsListId,
+        optionsVisible,
+        onKeyDown,
+        handleFocus,
+        handleBlur,
+        toggleOptionVisibility,
+    }
+
+    return  <StyledInputAndOptionsContainer ref={containerRef}>
+
+                <StyledInputContainer disabled={disabled ?? false} showOptions={optionsVisible ?? false} inputFocused={inputHasFocus}>
+                    <SelectInputBar     disabled={disabled ?? false}
+                                        hasSelection={hasSelection}
+                                        label={label}
+                                        placeholder={placeholder}
+                                        selectInputProps={selectInputProps}
+                                        selectedDisplayStr={selectedDisplayStr}
+                                        selectedOption={selectedOption}
+                                        clearInput={clearInput}
+                                    />
+                </StyledInputContainer>
+
+                {optionsVisible &&
+                    <OptionsList id={optionsListId}  options={options}  optionsMenuActions={optionsListInteractivity} />
+                }
+
+            </StyledInputAndOptionsContainer>
+}
+
+type SelectInputBarProps = Pick<I_SelectProps, "selectedOption" | "placeholder" | "disabled" | "label"> & {
+    hasSelection : boolean, 
+    selectInputProps : SelectInputProps, 
+    selectedDisplayStr : string | null, 
+    clearInput : () => void,
+}
+
+type SelectInputProps = {
+    activeDescendantId : string | undefined,
+    inputId : string,
+    optionsListId : string,
+    optionsVisible : boolean,
+    onKeyDown : (e : React.KeyboardEvent<HTMLDivElement>) => void, 
+    toggleOptionVisibility : () => void,
+    handleFocus : () => void,
+    handleBlur : () => void,
+}
+
+function SelectInputBar({disabled, label,hasSelection, placeholder, selectedDisplayStr, selectedOption, selectInputProps, clearInput} : SelectInputBarProps){
+    const {activeDescendantId, inputId, optionsListId, optionsVisible, handleFocus, handleBlur, onKeyDown, toggleOptionVisibility} = selectInputProps;
+    const toggleIconId = optionsVisible ? IconMediumId.arrowUp : IconMediumId.arrowDown;
+
+    return  <StyledInputBarLayout>
+                <StyledSelectedInput id={inputId}
+
+                                tabIndex={0}
+
+                                role={"combobox"}
+                                aria-activedescendant={activeDescendantId}
+                                aria-expanded={optionsVisible}
+                                aria-owns={optionsListId}
+
+                                onBlur={() => handleBlur()}
+                                onFocus={() => handleFocus()}
+                                onKeyDown={(e) => onKeyDown(e)}
+                                onMouseDown={() => toggleOptionVisibility()}
+                                >
+                    {selectedDisplayStr}
+                    {selectedOption === null && optionsVisible &&
+                        <StyledPlaceholderSpan>{placeholder}</StyledPlaceholderSpan>
+                    }
+                </StyledSelectedInput>
+
+                <StyledFloatingLabel htmlFor={inputId} disabled={disabled ?? false} floatUp={optionsVisible || hasSelection}>
+                    {label}
+                </StyledFloatingLabel>
+
+                { hasSelection &&
+                    <StyledCloseButton onClick={ clearInput }>
+                        <Icon idMedium={IconMediumId.close} />
+                    </StyledCloseButton>
+                }
+
+                <StyledToggleButton onClick = { toggleOptionVisibility } isActive={optionsVisible && hasSelection}>
+                    <Icon idMedium = {toggleIconId} />
+                </StyledToggleButton>
+                
+        </StyledInputBarLayout>
+}
+
+type OptionsListPropsType = Pick<I_SelectProps, "options"> & {
+    id: string,
+    optionsMenuActions: OptionsListInteractivity
+};
+
+type OptionsListInteractivity = {
+    activeId : number | null,
+    optionIdPrefix : string,
+    onOptionPick: (newInput : string) => void,
+    selectedOption : string | null,
+}
+
+function OptionsList({id, options, optionsMenuActions} : OptionsListPropsType){
+    let {activeId, optionIdPrefix, selectedOption, onOptionPick} = optionsMenuActions;
+    let screenReaderMsg : string = `${options.length} options found. Use up and down arrows to review.`;
+
+    return  <StyledOptionsContainer id={id}>
+                <StyledScreenReaderOnly id={"searchAnnouncement"} aria-live="assertive">
+                    {screenReaderMsg}
+                </StyledScreenReaderOnly>
+                {
+                    options?.map((data : OptionData, index : number) => {
+                        return  <Option key={index}
+                                        optionId={optionIdPrefix + index}
+                                        data={data}
+                                        onClick={() => onOptionPick(data)}
+                                        isHighlighted={index === activeId}
+                                        isSelected={selectedOption === data}
+                                        />
+                    })
+                }
+            </StyledOptionsContainer>
+}
+
+
+type OptionPropsType = {
+    data : OptionData,
+    isHighlighted : boolean,
+    isSelected : boolean,
+    onClick : () => void,
+    optionId : string,
+}
+
+function Option({optionId, onClick, isHighlighted, data, isSelected} : OptionPropsType){
+    return  <StyledOption   tabIndex={-1}
+                            id={optionId}
+                            role={"option"}
+                            onClick={() => onClick()}
+                            isHighlighted={isHighlighted}
+                            aria-selected={isSelected}
+                            >
+
+                <span>{data}</span>
+
+            {isSelected &&
+                <Icon idMedium={IconMediumId.check} />
+            }
+            </StyledOption>
+}

--- a/components/utils.tsx
+++ b/components/utils.tsx
@@ -1,9 +1,20 @@
-import {css} from 'styled-components';
+import styled, {css} from 'styled-components';
 
 
 export function isBlank(prop : any) : boolean{
     return prop === '' || prop === undefined || prop === null;
 }
+
+
+export const StyledScreenReaderOnly = styled.div`
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+`;
 
 
 export const visuallyHidden = css`
@@ -15,6 +26,42 @@ export const visuallyHidden = css`
     white-space: nowrap;
     width: 1px;
 `;
+
+
+type MoveWithMenuPropsType = {
+    e: React.KeyboardEvent, 
+    options : any[], 
+    activeId : number | null, 
+    setActiveId : (value: React.SetStateAction<number | null>) => void
+}
+export function moveWithinMenu({e, options, activeId, setActiveId} : MoveWithMenuPropsType){
+    if(options === null || options === undefined){
+        return;
+    }
+
+    let newId = activeId;
+
+    if(e.key === 'ArrowUp'){
+        if(newId === null || newId <= 0 ){ /* Loop from top to bottom */
+            newId = options.length - 1;
+        }
+        else{
+            newId = newId - 1;
+        }
+    }
+    
+    if(e.key === 'ArrowDown'){
+        if(newId === null || newId >= options.length - 1 ){ /* Loop from bottom to top */
+            newId = 0;
+        }
+        else{
+            newId = newId + 1;
+        }
+    }
+
+    setActiveId(newId);
+}
+
 
 export function convertRemToPixels(rem : number){
     return rem * parseFloat(getComputedStyle(document.documentElement).fontSize);

--- a/components/utils.tsx
+++ b/components/utils.tsx
@@ -30,7 +30,7 @@ export const visuallyHidden = css`
 
 type MoveWithMenuPropsType = {
     e: React.KeyboardEvent, 
-    options : any[], 
+    options : any[] | null | undefined, 
     activeId : number | null, 
     setActiveId : (value: React.SetStateAction<number | null>) => void
 }


### PR DESCRIPTION
Added Select and stories.
Renamed variables in Search during a failed attempt to share more components/functions than just StyledScreenReaderOnly and moveWithinMenu(). Keeping them that way in preparation for further attempts.