### PR TITLE
Add TooltipWrapper component

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -16,20 +16,6 @@ const customViewports = {
       height: '768px',
     },
   },
-  test_tooltipWrapper_onRight: {
-    name: 'test tooltipWrapper onRight',
-    styles: {
-      width: '700px',
-      height: '768px',
-    },
-  },
-  test_tooltipWrapper_onRight_prefSide: {
-    name: 'test tooltipWrapper onRight prefSide',
-    styles: {
-      width: '590px',
-      height: '768px',
-    },
-  },
 };
 
 export const parameters = {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -16,6 +16,20 @@ const customViewports = {
       height: '768px',
     },
   },
+  test_tooltipWrapper_onRight: {
+    name: 'test tooltipWrapper onRight',
+    styles: {
+      width: '700px',
+      height: '768px',
+    },
+  },
+  test_tooltipWrapper_onRight_prefSide: {
+    name: 'test tooltipWrapper onRight prefSide',
+    styles: {
+      width: '590px',
+      height: '768px',
+    },
+  },
 };
 
 export const parameters = {

--- a/components/Icons.stories.tsx
+++ b/components/Icons.stories.tsx
@@ -9,15 +9,14 @@ import {IconLargeId} from './IconsLarge';
 import {IconXLId} from './IconsExtraLarge';
 import {ICON_SIZES} from '../utils/Theme';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import Tooltip, {TOOLTIP_ARROW_POSITION} from './Tooltip';
-import { visuallyHidden, visuallyUnhidden } from '../utils/utils';
+import {TOOLTIP_ARROW_POSITION} from './Tooltip';
+import TooltipWrapper from './TooltipWrapper';
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
     title: 'UI Kit/Icon',
     component: Icon,
   } as ComponentMeta<typeof Icon>;
-
 
 const StyledIconsContainer = styled.div`
     display: flex;
@@ -28,24 +27,6 @@ const StyledIconsContainer = styled.div`
     margin-top: 0.75rem;
     width: 47.5rem;
     max-width: calc(100% - 2rem);
-`;
-
-const StyledTooltipContainer = styled.div`
-  ${visuallyHidden}
-`;
-
-const StyledIconWrapper = styled.div<{iconSize : string}>`
-  max-width: ${props => props.iconSize};
-  min-width: ${props => props.iconSize};
-
-  position: relative;
-  &:hover ${StyledTooltipContainer}{
-        ${visuallyUnhidden}
-        display: block;
-        position: absolute;
-        top: -3.1rem;
-        left: calc(-1.375rem + (${props => props.iconSize}/2));
-  }
 `;
 
 const StyledIconSection = styled.section`
@@ -77,16 +58,13 @@ function IconSection({iconSize} : IconSectionProps){
                 <StyledIconsContainer>
                 {
                     enumToArray(enumToConvert).map((name, index) => {
-                        return  <StyledIconWrapper key={index} iconSize={iconSize}>
+                        return  <TooltipWrapper key={index} text={`${name}`} arrowPos={TOOLTIP_ARROW_POSITION.bottomLeft}>
                                     <Icon   idSmall={idS ? index : undefined}
                                             idMedium={idM ? index : undefined}
                                             idLarge={idL ? index : undefined}
                                             idXL={idXL ? index : undefined} 
                                             />
-                                    <StyledTooltipContainer>
-                                        <Tooltip text={`${name}`} arrowPos={TOOLTIP_ARROW_POSITION.bottomLeft} />
-                                    </StyledTooltipContainer>
-                                </StyledIconWrapper>
+                                </TooltipWrapper>
                     })
                 }
                 </StyledIconsContainer>

--- a/components/Icons.stories.tsx
+++ b/components/Icons.stories.tsx
@@ -11,7 +11,7 @@ import {ICON_SIZES} from '../utils/Theme';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { TOOLTIP_ARROW_POSITION } from './Tooltip';
 import TooltipWrapper from './TooltipWrapper';
-import { TOOLTIP_POS } from './TooltipPositioned';
+import { TOOLTIP_MODE, POINTS_TO } from './TooltipPositioned';
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
@@ -61,8 +61,8 @@ function IconSection({iconSize} : IconSectionProps){
                     enumToArray(enumToConvert).map((name, index) => {
                         return  <TooltipWrapper key={index} 
                                                 text={`${name}`} 
-                                                pos={TOOLTIP_POS.center} 
-                                                arrowPos={TOOLTIP_ARROW_POSITION.bottomLeft}
+                                                pointTo={POINTS_TO.center} 
+                                                mode={TOOLTIP_MODE.aboveArrowLeft}
                                                 >
                                     <Icon   idSmall={idS ? index : undefined}
                                             idMedium={idM ? index : undefined}

--- a/components/Icons.stories.tsx
+++ b/components/Icons.stories.tsx
@@ -9,8 +9,9 @@ import {IconLargeId} from './IconsLarge';
 import {IconXLId} from './IconsExtraLarge';
 import {ICON_SIZES} from '../utils/Theme';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import {TOOLTIP_ARROW_POSITION} from './Tooltip';
+import { TOOLTIP_ARROW_POSITION } from './Tooltip';
 import TooltipWrapper from './TooltipWrapper';
+import { TOOLTIP_POS } from './TooltipPositioned';
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
@@ -58,7 +59,11 @@ function IconSection({iconSize} : IconSectionProps){
                 <StyledIconsContainer>
                 {
                     enumToArray(enumToConvert).map((name, index) => {
-                        return  <TooltipWrapper key={index} text={`${name}`} arrowPos={TOOLTIP_ARROW_POSITION.bottomLeft}>
+                        return  <TooltipWrapper key={index} 
+                                                text={`${name}`} 
+                                                pos={TOOLTIP_POS.center} 
+                                                arrowPos={TOOLTIP_ARROW_POSITION.bottomLeft}
+                                                >
                                     <Icon   idSmall={idS ? index : undefined}
                                             idMedium={idM ? index : undefined}
                                             idLarge={idL ? index : undefined}

--- a/components/Tooltip.stories.tsx
+++ b/components/Tooltip.stories.tsx
@@ -45,3 +45,9 @@ export const Right = Template.bind({});
 Right.args = {
     arrowPos: TOOLTIP_ARROW_POSITION.right
 }
+
+export const Fullscreen = Template.bind({});
+Fullscreen.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.right,
+    fullscreenMode: true,
+}

--- a/components/Tooltip.stories.tsx
+++ b/components/Tooltip.stories.tsx
@@ -7,15 +7,18 @@ export default {
     title: 'UI Kit/Tooltip',
     component: Tooltip,
     args: {
-        text: "Your Text in Tooltip"
+        text: "Your Text in Tooltip",
     }
   } as ComponentMeta<typeof Tooltip>;
 
-const Template: ComponentStory<typeof Tooltip> = args => <Tooltip {...args} />;
+const Template: ComponentStory<typeof Tooltip> = args => {
+    const id = React.useId();
+    return <Tooltip {...args} id={id} />
+};
 
 export const TopLeft = Template.bind({});
 TopLeft.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.topLeft
+    arrowPos: TOOLTIP_ARROW_POSITION.topLeft,
 }
 
 export const TopRight = Template.bind({});

--- a/components/Tooltip.tsx
+++ b/components/Tooltip.tsx
@@ -134,7 +134,7 @@ const rightTheme : TooltipArrowThemeProps = {
     yKey: "top",
 }
 
-function getTooltipTheme(arrowPos : TOOLTIP_ARROW_POSITION) : TooltipArrowThemeProps{
+function getTooltipTheme(arrowPos? : TOOLTIP_ARROW_POSITION) : TooltipArrowThemeProps{
     switch(arrowPos){
         case TOOLTIP_ARROW_POSITION.bottomLeft:
             return bottomLeftTheme;
@@ -175,10 +175,11 @@ const StyledTooltip = styled.div.attrs<ThemeProps<TooltipArrowThemeProps>, Toolt
     border: 0.0625rem solid ${props => props.borderColor};
     border-radius: ${LAYOUT.borderRadius};
     box-shadow: ${SHADOW.default};
-    max-width: 100%;
+    max-width: 99vw;
     padding: 0.6875rem 1rem 0.6875rem 0.9375rem;
     position: relative;
     width: fit-content;
+    max-width: 100%;
     
     &:before,
     &:after{
@@ -229,16 +230,17 @@ const StyledArrowShadow = styled.div`
     ${props => props.theme.yKey}: ${props => props.theme.pos.y.shadow};
 `;
 
-interface I_TooltipProps{
+export interface I_TooltipProps{
+    id : string,
     text : string,
-    arrowPos : TOOLTIP_ARROW_POSITION
+    arrowPos? : TOOLTIP_ARROW_POSITION
 }
 
-export default function Tooltip({text, arrowPos} : I_TooltipProps){
+export default function Tooltip({id, text, arrowPos} : I_TooltipProps){
     const theme = getTooltipTheme(arrowPos);
 
     return  <ThemeProvider theme = {theme}>
-                <StyledTooltip>
+                <StyledTooltip role="tooltip" id={id}>
                     <Paragraph size={3} colour={PALETTE.black}>
                         {text}
                     </Paragraph>

--- a/components/Tooltip.tsx
+++ b/components/Tooltip.tsx
@@ -4,7 +4,7 @@ import { LAYOUT, PALETTE, SHADOW } from '../utils/Theme';
 import Paragraph from './Paragraph';
 import {PositionsObj} from './TooltipWrapper';
 
-export const enum TOOLTIP_ARROW_POSITION{
+export enum TOOLTIP_ARROW_POSITION{
     topLeft = "topLeft",
     topRight = "topRight",
     bottomLeft = "bottomLeft",
@@ -188,8 +188,8 @@ const StyledTooltipFullscreen = styled(StyledTooltipBase)<{topStr : string | und
     max-height: calc(100vh - 1rem);
     overflow-y: auto;
     position: fixed;
-    top: ${props => props.topStr ? props.topStr : "50%"};
-    width: calc(100vw - 1rem);  
+    top: ${props => props.topStr ? props.topStr : "0.5rem"};
+    width: calc(100vw - 1.25rem);  
 `;
 
 const StyledTooltip = styled(StyledTooltipBase)`
@@ -245,11 +245,19 @@ const StyledArrowShadow = styled.div`
 `;
 
 function getCssForFullscreenTop({wrapperPos, height} : {wrapperPos : PositionsObj | undefined, height : number | undefined}){
-    if(wrapperPos){
-        return `calc(${wrapperPos.bottom}px + 8px)`;
-    }
-    else if(height){
-        return `calc(50% - ${height / 2}px)`;
+    if(wrapperPos && height){
+        const padding = 8;
+        let topNum : number;
+
+        if(wrapperPos.top - height - padding > 0){
+            topNum = wrapperPos.top - height - padding;
+            return `${topNum}px`;
+        }
+
+        if(wrapperPos.bottom + height + padding < window.innerHeight){
+            topNum = wrapperPos.bottom + padding;
+            return `${topNum}px`;
+        }
     }
     return undefined;
 }
@@ -275,7 +283,6 @@ export default function Tooltip({arrowPos, fullscreenMode, id, text, wrapperPos 
     }
 
     const theme = getTooltipTheme(arrowPos);
-    
     return  <ThemeProvider theme = {theme}>
                 <StyledTooltip role="tooltip" id={id} ref={ref}>
                     <TooltipContents text={text} />

--- a/components/TooltipPositioned.tsx
+++ b/components/TooltipPositioned.tsx
@@ -1,0 +1,402 @@
+/*
+    For use with TooltipWrapper.
+    Automatically positions the Tooltip relative to the wrapper, based on the 
+    Tooltip's arrowPos (it will point to the target DOM element) and the TOOLTIP_POS,
+    (which is used to pick one of three locations along the target).
+*/
+import React from 'react';
+import styled from 'styled-components';
+import Tooltip, {I_TooltipProps, TOOLTIP_ARROW_POSITION as ARROW_POS} from './Tooltip';
+import { convertRemToPixels } from '../utils/utils';
+import { PositionsObj } from './TooltipWrapper';
+import updateToFit from '../utils/tooltipPosUpdateToFit';
+
+export enum TOOLTIP_POS{
+    start = "start",
+    center = "center",
+    end = "end"
+}
+
+// For topX and bottomX arrows only: the distance between the edge of the tooltip and the static arrow point.
+// This can be used to adjust tooltip positioning to make it relative to the arrow point.
+const OFFSET_ARROW_PERP = "1.375rem"; 
+const OFFSET_ARROW_PERP_PX = convertRemStrToPx(OFFSET_ARROW_PERP);
+
+// For all arrow types. Arbitrary/subjective offset. "Start" and "end" don't look right if they point to 
+// the very first pixel of the target element, so move them inwards a bit, so they look nicer.
+const OFFSET_EDGE = "0.6875rem";
+const OFFSET_EDGE_PX = convertRemStrToPx(OFFSET_EDGE);
+
+// For all arrow types. Offset to leave space between the tooltip and the target: for the arrow plus a
+// little artistic-extra.
+const OFFSET_ARROW_OUTWARDS = "0.4375rem";
+const OFFSET_ARROW_OUTWARDS_PX = convertRemStrToPx(OFFSET_ARROW_OUTWARDS);
+const NEXT_TO_TARGET = `calc(100% + ${OFFSET_ARROW_OUTWARDS})`;
+
+function convertRemStrToPx(str : string) : number{
+    /* Guide for if you haven't used regex in a while:
+       ---------------------------------------------------------------------------------------------------
+        ^               Beginning of string
+        -?              Optional "-" to support negative rem strings
+        (               Begin a group. This group will define what's considered "a valid number".
+        \d*[1-9]\d*         A number of any size, but with at least one non-zero digit.
+        (\.\d+)?            Optional: Decimal point with at least one number after it.
+        |               OR
+        0*                  Any number of 0s, including none at all.
+        \.                  A decimal point.
+        \d*[1-9]\d*         A number of any size, but with at least one non-zero digit.
+        )               End of the "a valid number" group.
+        (?=rem$)        Look ahead to make sure the valid number is followed by "rem" and then the string ends.
+
+        Matches -5rem, 12rem, 1.2rem and .25rem. Does not match _1rem, 5rems, 0rem, 0.0rem, 0.rem, rem.
+    */
+    const regex = /^-?(\d*[1-9]\d*(\.\d+)?|0*\.\d*[1-9]\d*)(?=rem$)/;
+    const result = str.trim().match(regex);
+    if(result !== null && result.length > 0){
+        return convertRemToPixels(parseFloat(result[0]));
+    }
+    return 0;
+}
+
+
+// Take the ArrowPos chosen for the tooltip and set its implications for TooltipResponsive.
+export type T_ArrowPosWithSettings = {
+    arrow : ARROW_POS,
+    defaultPerpPos : TOOLTIP_POS,
+    fromTop : boolean,
+    fromLeft : boolean,
+    atSideOfTarget : boolean,
+    fallbackTop : boolean | undefined,
+    fallbackLeft : boolean | null,
+}
+export function addSettingsToArrowPos(arrowPos: ARROW_POS | undefined) : T_ArrowPosWithSettings{
+    let fromTop : boolean;
+    let fromLeft : boolean;
+    let atSideOfTarget : boolean;
+    let fallbackTop : boolean | undefined; // undefined = depends on start/center/end
+    let fallbackLeft : boolean | null; // null = not relevant for this arrowPos
+
+    let defaultPerpPos : TOOLTIP_POS = TOOLTIP_POS.start;
+    let arrow = arrowPos ?? ARROW_POS.bottomLeft; // undefined arrowPos is covered here
+
+    switch(arrow){
+        case ARROW_POS.bottomLeft:
+            fromTop = false;
+            fromLeft = true;
+            atSideOfTarget = false;
+            fallbackTop = false;
+            fallbackLeft = null;
+            break;
+
+        case ARROW_POS.bottomRight:
+            defaultPerpPos = TOOLTIP_POS.end;
+            fromTop = false;
+            fromLeft = false;
+            atSideOfTarget = false;
+            fallbackTop = false;
+            fallbackLeft = null;
+            break;
+
+        case ARROW_POS.left:
+            fromTop = true;
+            fromLeft = true;
+            atSideOfTarget = true;
+            fallbackTop = undefined;
+            fallbackLeft = false;
+            break;
+
+        case ARROW_POS.topLeft:
+            fromTop = true;
+            fromLeft = true;
+            atSideOfTarget = false;
+            fallbackTop = true;
+            fallbackLeft = null;
+            break;
+
+        case ARROW_POS.topRight:
+            defaultPerpPos = TOOLTIP_POS.end;
+            fromTop = true;
+            fromLeft = false;
+            atSideOfTarget = false;
+            fallbackTop = true;
+            fallbackLeft = null;
+            break;
+
+        case ARROW_POS.right:
+            fromTop = true;
+            fromLeft = false;
+            atSideOfTarget = true;
+            fallbackTop = undefined;
+            fallbackLeft = true;
+            break;
+
+        // no default case: the line above the switch covers "undefined"; all enum options must be covered
+    }
+
+    return {
+        arrow,
+        defaultPerpPos,
+        fromTop,
+        fromLeft,
+        atSideOfTarget,
+        fallbackTop,
+        fallbackLeft,
+    }
+}
+
+
+
+// Styled-Component
+type T_Positioning = {
+    top: string,
+    right: string,
+    bottom: string,
+    left : string,
+}
+type T_PropsTooltipWrapper = {
+    pos: T_Positioning
+}
+type T_OutputTypeTooltipWrapperAttrs = {
+    style : T_Positioning
+}
+// Position is in the "style" attr because otherwise screen resizing generates hundreds of CSS classes.
+const StyledTooltipContainer = styled.div.attrs<
+    T_PropsTooltipWrapper,
+    T_OutputTypeTooltipWrapperAttrs
+    >((props : T_PropsTooltipWrapper) => {
+        return {
+            style: {
+                    top: props.pos ? props.pos.top : "0",
+                    right: props.pos ? props.pos.right : "0",
+                    bottom: props.pos ? props.pos.bottom : "0",
+                    left: props.pos ? props.pos.left : "0",
+                },
+        }
+    })<T_PropsTooltipWrapper>`
+
+    display: block;
+    position: absolute;
+    z-index: 5;
+    width: max-content;
+    max-width: 25rem;
+`;
+
+
+// Prepare the settings to be used in the style attribute
+export type T_TooltipOptions = {
+    settings : T_ArrowPosWithSettings,
+    perpPos : TOOLTIP_POS,
+}
+type T_TooltipOptionsWithHeight = T_TooltipOptions & { 
+    heightInPx : number,
+}
+function getPositioningSettings({perpPos, settings, heightInPx} : T_TooltipOptionsWithHeight) : T_Positioning{
+    let posSettings = {
+        top: "auto",
+        right: "auto",
+        bottom: "auto",
+        left: "auto",
+    }
+
+    const strX = getCssForXAxis({perpPos, settings});
+    if(settings.fromLeft){
+        posSettings.left = strX;
+    }
+    else{
+        posSettings.right = strX;
+    }
+
+    const strY = getCssForYAxis({perpPos, settings, heightInPx});
+    if(settings.fromTop){
+        posSettings.top = strY;
+    }
+    else{
+        posSettings.bottom = strY;
+    }
+
+    return posSettings;
+}
+
+
+function getCssForXAxis({perpPos, settings} : T_TooltipOptions) : string{
+    if(settings.atSideOfTarget){
+        return NEXT_TO_TARGET;
+    }
+
+    const offset = `${getXOffsetPx({perpPos, settings})}px`;
+    const offsetCloseSide = `-${offset}`;
+    const offsetFarSide = `calc(100% - ${offset})`;
+
+    switch(perpPos){
+        case TOOLTIP_POS.start:
+            return settings.fromLeft ? offsetCloseSide : offsetFarSide;
+
+        case TOOLTIP_POS.end:
+            return settings.fromLeft ? offsetFarSide : offsetCloseSide;
+
+        case TOOLTIP_POS.center:
+            return `calc(50% - ${offset})`;
+
+        default:
+            return "0";
+    } 
+}
+
+
+function getCssForYAxis({perpPos, settings, heightInPx} : T_TooltipOptionsWithHeight) : string{
+    if(!settings.atSideOfTarget){
+        return NEXT_TO_TARGET;
+    }
+
+    const heightOffset = `${heightInPx / 2}px`;
+    switch(perpPos){
+        case TOOLTIP_POS.start:
+            return `calc(${OFFSET_EDGE} - ${heightOffset})`;
+
+        case TOOLTIP_POS.end:
+            return `calc(100% - ${OFFSET_EDGE} - ${heightOffset})`;
+
+        case TOOLTIP_POS.center:
+            return `calc(50% - ${heightOffset})`;
+            
+        default:
+            return "0";
+    }
+}
+
+
+
+// Get X-axis offsets in pixels (converted from rem, so responsive)
+export function getXOffsetPx({settings, perpPos} : T_TooltipOptions) : number{
+    if(settings.atSideOfTarget){
+        return OFFSET_ARROW_OUTWARDS_PX;
+    }
+
+    const farSideOffset : number = OFFSET_EDGE_PX + OFFSET_ARROW_PERP_PX;
+    switch(perpPos){
+        case TOOLTIP_POS.start:
+            return settings.fromLeft ? OFFSET_EDGE_PX : farSideOffset;
+
+        case TOOLTIP_POS.end:
+            return settings.fromLeft ? farSideOffset : OFFSET_EDGE_PX;
+
+        case TOOLTIP_POS.center:
+            return OFFSET_ARROW_PERP_PX;
+        
+        default:
+            return 0;
+    }
+}
+
+
+// Responsiveness Helper types
+export type T_DOMElementSettings = {
+    wrapperPos: PositionsObj,
+    preferredWidth : number,
+}
+
+export type T_MaxSpaceToEachSide = {
+    maxSpaceGoingLeft : number,
+    maxSpaceGoingRight : number,
+}
+
+
+// Hooks
+type useFullscreenModeProps = T_MaxSpaceToEachSide & Pick<T_DOMElementSettings, "preferredWidth">;
+function useFullscreenMode({maxSpaceGoingLeft, maxSpaceGoingRight, preferredWidth} : useFullscreenModeProps) : boolean{
+    const [fullscreenMode, setFullscreenMode] = React.useState<boolean>(false);
+
+    React.useEffect(() => {
+        window.addEventListener("resize", updateFullscreenMode);
+        return () => window.removeEventListener("resize", updateFullscreenMode);
+    }, []);
+
+    function updateFullscreenMode(){
+        const needFullscreen =  preferredWidth > maxSpaceGoingLeft
+                                && preferredWidth > maxSpaceGoingRight;
+
+        if(fullscreenMode && !needFullscreen){
+            setFullscreenMode(false);
+        }
+        else if(!fullscreenMode && needFullscreen){
+            setFullscreenMode(true);
+        }
+    }
+
+    updateFullscreenMode();
+
+    return fullscreenMode;
+}
+
+type T_UseDimensionsProps = {
+    ref : React.MutableRefObject<HTMLDivElement | HTMLElement | null>,
+    text? : string,
+}
+type T_Dimensions = {
+    height : number,
+    width: number,
+}
+function useOriginalDimensions({ref, text} : T_UseDimensionsProps) : T_Dimensions{
+    const [measurements, setMeasurements] = React.useState<T_Dimensions>(getDimensions);
+
+    function getDimensions(){
+        return {
+            height: ref.current ? ref.current.offsetHeight : 0,
+            width: ref.current ? ref.current.offsetWidth : 0,
+        }
+    }
+
+    function updateDimensions(){
+        if(ref.current){
+            setMeasurements(getDimensions());
+        }
+    }
+
+    React.useLayoutEffect(() => {
+        updateDimensions();
+    }, []);
+
+    React.useEffect(() => {
+        updateDimensions();
+    }, [text]);
+
+    return measurements;
+}
+
+
+type T_TooltipPositionedProps =   Pick<I_TooltipProps, "arrowPos" | "id" | "text"> 
+                                & Pick<T_DOMElementSettings, "wrapperPos"> 
+                                & {
+                                    pos? : TOOLTIP_POS,
+                                };
+export default function TooltipPositioned({arrowPos, pos, text, id, wrapperPos} : T_TooltipPositionedProps){
+    const ref = React.useRef<HTMLDivElement | null>(null);
+    const {height: preferredHeight, width: preferredWidth} = useOriginalDimensions({ref, text});
+
+    let settings = addSettingsToArrowPos(arrowPos);
+    let perpPos = pos ?? settings.defaultPerpPos;
+
+    let maxSpaceGoingLeft = wrapperPos.right + OFFSET_EDGE_PX;
+    let maxSpaceGoingRight = window.innerWidth - wrapperPos.left + OFFSET_EDGE_PX;  
+
+    const fullscreenMode = useFullscreenMode({maxSpaceGoingLeft, maxSpaceGoingRight, preferredWidth});
+    if(!fullscreenMode){
+        let responsive = updateToFit({settings, perpPos, fullscreenMode, wrapperPos, preferredWidth, maxSpaceGoingLeft, maxSpaceGoingRight});
+        settings = responsive.settings;
+        perpPos = responsive.perpPos;
+    }
+
+    return  <StyledTooltipContainer ref={ref} 
+                                    pos={getPositioningSettings({perpPos, settings, heightInPx: preferredHeight})}
+                                    >
+                <Tooltip    arrowPos={settings.arrow}
+                            fullscreenMode={fullscreenMode}
+                            id={id} 
+                            text={text}
+                            wrapperPos={wrapperPos}
+                />
+            </StyledTooltipContainer>
+}
+
+
+

--- a/components/TooltipWrapper.stories.tsx
+++ b/components/TooltipWrapper.stories.tsx
@@ -1,33 +1,25 @@
-import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
 import TooltipWrapper from './TooltipWrapper';
-import { TOOLTIP_POS } from './TooltipPositioned';
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { TOOLTIP_MODE, POINTS_TO } from './TooltipPositioned';
 
-import { TOOLTIP_ARROW_POSITION } from './Tooltip';
 import styled from 'styled-components';
 import { PALETTE, TYPOGRAPHY } from '../utils/Theme';
 
-// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const TEXT = "Your Text in Tooltip ";
-const FULL_ROW = TEXT + TEXT + TEXT;
+const FULL_ROW = TEXT + TEXT + TEXT + TEXT;
 const THREE_ROWS = FULL_ROW + FULL_ROW + FULL_ROW;
-const WALL = THREE_ROWS + THREE_ROWS + THREE_ROWS;
 
-export default {
+const meta: Meta<typeof TooltipWrapper> = {
     title: 'UI Kit/TooltipWrapper',
     component: TooltipWrapper,
     args: {
         text: TEXT,
         lockVisible: true,
     },
-    decorators: [
-            (Story) => (
-              <div style={{ margin: '10rem 0 0 10rem' }}>
-                <Story />
-              </div>
-            ),
-    ],
-  } as ComponentMeta<typeof TooltipWrapper>;
+  };
+  
+export default meta;
+type Story = StoryObj<typeof TooltipWrapper>;
 
 const StyledBox = styled.div`
     display: flex;
@@ -45,213 +37,344 @@ const StyledBox = styled.div`
     }
 `;
 
-const FunctioningTemplate: ComponentStory<typeof TooltipWrapper> = args => {
-    return  <TooltipWrapper {...args}>
-                <StyledBox>
-                    <span>Hover, focus or tap me :)</span>
-                </StyledBox>
-            </TooltipWrapper>
-}
-
-const Template: ComponentStory<typeof TooltipWrapper> = args => {
-    return  <TooltipWrapper {...args}>
-                <StyledBox>
-                    <span>Tooltip target</span>
-                </StyledBox>
-            </TooltipWrapper>
-}
-
-export const DefaultFunctional = FunctioningTemplate.bind({});
-DefaultFunctional.args = {
-    lockVisible: false
-}
-
-export const AboveLeft = Template.bind({});
-AboveLeft.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.bottomLeft,
-}
-
-export const AboveRight = Template.bind({});
-AboveRight.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.bottomRight,
-}
-
-export const BelowLeft = Template.bind({});
-BelowLeft.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.topLeft,
-}
-
-export const BelowRight = Template.bind({});
-BelowRight.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.topRight,
-}
-
-export const OnRight = Template.bind({});
-OnRight.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.left,
-}
-
-export const OnLeft = Template.bind({});
-OnLeft.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.right,
-}
-
-/* 
-    Story with a full-width tooltip. Manually resizing the window allows you to check 
-    exactly when it repositions. Not much use in automated testing though: it doesn't 
-    force an overflow.
-*/
-// export const ManualOverflowTest = Template.bind({});
-// ManualOverflowTest.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.left,
-//     text: FULL_ROW,
-// }
-
-export const OverflowOnLeft = Template.bind({});
-OverflowOnLeft.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.right,
-    text: FULL_ROW,
-}
-
-export const OverflowOnRightPrefSideFits = Template.bind({});
-OverflowOnRightPrefSideFits .args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.left,
-    text: TEXT + TEXT,
-}
-OverflowOnRightPrefSideFits .parameters = {
-    viewport: {
-        defaultViewport: 'test_tooltipWrapper_onRight_prefSide',
-    }
-}
-
-export const OverflowOnRight = Template.bind({});
-OverflowOnRight.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.left,
-    text: FULL_ROW,
-}
-OverflowOnRight.parameters = {
-    viewport: {
-        defaultViewport: 'test_tooltipWrapper_onRight',
-    }
-}
-
-export const OverflowFullscreen = Template.bind({});
-OverflowFullscreen.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.left,
-    text: WALL,
-}
-OverflowFullscreen.parameters = {
-    viewport: {
-      defaultViewport: 'iphone5',
+export const DefaultFunctional: Story = {
+    args: {
+        lockVisible: false,
     },
+    // @ts-ignore : maybe YOU can't find the arguments, TS, but everyone else can, so HUSH
+    render: ({mode, lockVisible, pointTo, text, className}) =>
+    <TooltipWrapper mode={mode} lockVisible={lockVisible} pointTo={pointTo} text={text} className={className}>
+            <StyledBox>
+                <span>Hover, focus or tap me :)</span>
+            </StyledBox>
+        </TooltipWrapper>,
+    decorators: [
+            (Story) => (
+              <div style={{ margin: '10rem  0 0 10rem' }}>
+                <Story />
+              </div>
+            ),
+    ],
+};
+
+export const AboveLeft: Story = {
+    args: {
+        mode: TOOLTIP_MODE.aboveWithArrowLeft,
+    },
+    // @ts-ignore : maybe YOU can't find the "text" argument, TS, but everyone else can, so HUSH
+    render: ({mode, pointTo, text, lockVisible}) =>
+        <TooltipWrapper text={text} pointTo={pointTo} mode={mode} lockVisible={lockVisible}>
+            <StyledBox>
+                <span>Tooltip target</span>
+            </StyledBox>
+        </TooltipWrapper>,
+    decorators: [
+        (Story) => (
+            <div style={{ margin: '10rem  0 0 10rem' }}>
+            <Story />
+            </div>
+        ),
+    ],
+};
+
+export const AboveRight: Story = {
+    ...AboveLeft,
+    args: {
+        mode: TOOLTIP_MODE.aboveWithArrowRight,
+    }
+}
+
+export const BelowRight: Story = {
+    ...AboveLeft,
+    args: {
+        mode: TOOLTIP_MODE.belowWithArrowRight,
+    }
+}
+
+export const BelowLeft: Story = {
+    ...AboveLeft,
+    args: {
+        mode: TOOLTIP_MODE.belowWithArrowLeft,
+    }
+}
+
+export const LeftMid: Story = {
+    ...AboveLeft,
+    args: {
+        mode: TOOLTIP_MODE.leftWithArrowMid,
+    }
+}
+
+export const RightMid: Story = {
+    ...AboveLeft,
+    args: {
+        mode: TOOLTIP_MODE.rightWithArrowMid,
+    }
+}
+
+
+// || Stories testing how the tooltip behaves when there isn't enough space for it
+/* 
+    In order to create the "not enough space" error, the plan is:
+
+    1) The target element "naturally" won't have space to the top or left. Create
+       space there by adding a margin to the decorator (or not, as the case may be).
+       Note: don't add the margin to the target element, because that messes up
+       the tooltip positioning.
+    2) The target element "naturally" would have space below and to the right. Get rid
+       of that by increasing the dimensions of the target element, so it fills the screen.
+
+    This means both the decorator and the render function need information about which/how
+    many sides need space. Solution: a "T_Space" variable. Set four bools for top, right,
+    bottom and left before the story and pass it in. The decorator will convert that into 
+    margins and the styled-component will convert that into dimensions.
+*/
+type T_Space = {
+    top : boolean,
+    right : boolean,
+    bottom : boolean,
+    left : boolean,
+}
+
+const REM_TO_FIT_TOOLTIP = 10;
+const MIN_MARGIN = 0.5;
+const STORYBOOK_PADDING = "1rem";
+
+const StyledFillerBox = styled.div.attrs<
+    {space : T_Space},
+    {tooltipSpaceX : number, tooltipSpaceY : number}
+    >((props) => {
+            return {
+                tooltipSpaceX: getSpaceForTooltips(props.space.left, props.space.right),
+                tooltipSpaceY: getSpaceForTooltips(props.space.top, props.space.bottom),
+            }
+        }
+    )
+    <{space : T_Space}>`
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-width: calc(100vw - ${STORYBOOK_PADDING} - ${props => props.tooltipSpaceX ? `${props.tooltipSpaceX}rem` : "0px"});
+    min-height: calc(100vh - ${STORYBOOK_PADDING} - ${props => props.tooltipSpaceY ? `${props.tooltipSpaceY}rem` : "0px"});
+    background: ${PALETTE.primary};
+    padding: 1rem;
+  
+    span{
+        ${TYPOGRAPHY.p2}
+        color: ${PALETTE.white};
+        text-align: center;
+    }
+`;
+
+function getSpaceForTooltips(wantSpaceA : boolean, wantSpaceB : boolean){
+    if(wantSpaceA && wantSpaceB){
+        return REM_TO_FIT_TOOLTIP * 2;
+    }
+    if(wantSpaceA || wantSpaceB){
+        return REM_TO_FIT_TOOLTIP + MIN_MARGIN;
+    }
+    return MIN_MARGIN * 2;
+}
+
+function getMargin(sideFits : boolean){
+    const fits = `${REM_TO_FIT_TOOLTIP}rem`;
+    const noFit = `${MIN_MARGIN}rem`;
+    return sideFits ? fits : noFit;
+}
+
+const getDecorator = (space : T_Space) => {
+    const marginStr = `${getMargin(space.top)} ${getMargin(space.right)} ${getMargin(space.bottom)} ${getMargin(space.left)}`;
+    // @ts-ignore : It's working just fine with "implicit any" on Story, so kindly HUSH
+    return [(Story) => (<div style={{ margin: marginStr }}><Story /></div>)];
+}
+
+const SPACE_ALL = {
+    top: true,
+    right: true,
+    bottom: true,
+    left: true,
+};
+const NO_SPACE = {
+    top: false,
+    right: false,
+    bottom: false,
+    left: false,
+}
+let space : T_Space;
+
+
+space = {...SPACE_ALL, top: false};
+export const OverflowNoSpaceAbove: Story = {
+    args: {
+        mode: TOOLTIP_MODE.aboveWithArrowLeft,
+        pointTo: POINTS_TO.start,
+        space: space
+    },
+    // @ts-ignore : TS says it can't find these variables in args, but it's working as-is, so meh
+    render: ({mode, lockVisible, pointTo, text, className, space}) => 
+        <TooltipWrapper mode={mode} lockVisible={lockVisible} pointTo={pointTo} text={text} className={className}>
+            <StyledFillerBox space={space} >
+                <span>{mode} & {pointTo}</span>
+                <span>Target that fills a lot of space, so we can test the responsive overflow handling.</span>
+            </StyledFillerBox>
+        </TooltipWrapper>
+    ,
+    decorators: getDecorator(space),
 };
 
 
+space = {...SPACE_ALL, left: false};
+export const OverflowNoSpaceLeft: Story = {
+    args: {
+        mode: TOOLTIP_MODE.leftWithArrowMid,
+        pointTo: POINTS_TO.start,
+        space: space,
+    },
+    render: OverflowNoSpaceAbove.render,
+    decorators: getDecorator(space),
+};
 
-// export const BottomLeftStart = Template.bind({});
-// BottomLeftStart.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.bottomLeft,
-//     pos: TOOLTIP_POS.start,
-// }
+space = {...SPACE_ALL, right: false};
+export const OverflowNoSpaceRight: Story = {
+    args: {
+        mode: TOOLTIP_MODE.rightWithArrowMid,
+        pointTo: POINTS_TO.start,
+        space: space,
+    },
+    render: OverflowNoSpaceAbove.render,
+    decorators: getDecorator(space),
+};
 
-export const BottomLeftCenter = Template.bind({});
-BottomLeftCenter.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.bottomLeft,
-    pos: TOOLTIP_POS.center,
-}
+space = {...SPACE_ALL, bottom: false};
+export const OverflowNoSpaceBelow: Story = {
+    args: {
+        mode: TOOLTIP_MODE.belowWithArrowLeft,
+        pointTo: POINTS_TO.start,
+        space: space,
+    },
+    render: OverflowNoSpaceAbove.render,
+    decorators: getDecorator(space),
+};
 
-export const BottomLeftEnd = Template.bind({});
-BottomLeftEnd.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.bottomLeft,
-    pos: TOOLTIP_POS.end,
-}
+space = {...SPACE_ALL, top: false, left: false};
+export const OverflowNoSpaceAboveOrLeft: Story = {
+    args: {
+        mode: TOOLTIP_MODE.aboveWithArrowRight,
+        pointTo: POINTS_TO.start,
+        space: space,
+    },
+    render: OverflowNoSpaceAbove.render,
+    decorators: getDecorator(space),
+};
 
-export const BottomRightStart = Template.bind({});
-BottomRightStart.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.bottomRight,
-    pos: TOOLTIP_POS.start,
-}
+space = {...SPACE_ALL, top: false, right: false};
+export const OverflowNoSpaceAboveOrRight: Story = {
+    args: {
+        mode: TOOLTIP_MODE.aboveWithArrowLeft,
+        pointTo: POINTS_TO.end,
+        space: space,
+    },
+    render: OverflowNoSpaceAbove.render,
+    decorators: getDecorator(space),
+};
 
-export const BottomRightCenter = Template.bind({});
-BottomRightCenter.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.bottomRight,
-    pos: TOOLTIP_POS.center,
-}
+space = {...SPACE_ALL, top: false, bottom: false};
+export const OverflowNoSpaceAboveOrBelow: Story = {
+    args: {
+        mode: TOOLTIP_MODE.belowWithArrowRight,
+        pointTo: POINTS_TO.end,
+        space: space,
+    },
+    render: OverflowNoSpaceAbove.render,
+    decorators: getDecorator(space),
+};
 
-// export const BottomRightEnd = Template.bind({});
-// BottomRightEnd.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.bottomRight,
-//     pos: TOOLTIP_POS.end,
-// }
+space = {...SPACE_ALL, bottom: false, left: false};
+export const OverflowNoSpaceBelowOrLeft: Story = {
+    args: {
+        mode: TOOLTIP_MODE.belowWithArrowLeft,
+        pointTo: POINTS_TO.end,
+        space: space,
+    },
+    render: OverflowNoSpaceAbove.render,
+    decorators: getDecorator(space),
+};
 
-// export const TopLeftStart = Template.bind({});
-// TopLeftStart.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.topLeft,
-//     pos: TOOLTIP_POS.start,
-// }
+space = {...SPACE_ALL, bottom: false, right: false};
+export const OverflowNoSpaceBelowOrRight: Story = {
+    args: {
+        mode: TOOLTIP_MODE.rightWithArrowMid,
+        pointTo: POINTS_TO.center,
+        space: space,
+    },
+    render: OverflowNoSpaceAbove.render,
+    decorators: getDecorator(space),
+};
 
-export const TopLeftCenter = Template.bind({});
-TopLeftCenter.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.topLeft,
-    pos: TOOLTIP_POS.center,
-}
+space = {...SPACE_ALL, left: false, right: false};
+export const OverflowNoSpaceLeftOrRight: Story = {
+    args: {
+        mode: TOOLTIP_MODE.leftWithArrowMid,
+        pointTo: POINTS_TO.center,
+        space: space,
+    },
+    render: OverflowNoSpaceAbove.render,
+    decorators: getDecorator(space),
+};
 
-export const TopLeftEnd = Template.bind({});
-TopLeftEnd.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.topLeft,
-    pos: TOOLTIP_POS.end,
-}
+space = {...NO_SPACE, top: true};
+export const OverflowOnlySpaceAbove: Story = {
+    args: {
+        mode: TOOLTIP_MODE.belowWithArrowLeft,
+        pointTo: POINTS_TO.center,
+        space: space,
+    },
+    render: OverflowNoSpaceAbove.render,
+    decorators: getDecorator(space),
+};
 
-export const TopRightStart = Template.bind({});
-TopRightStart.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.topRight,
-    pos: TOOLTIP_POS.start,
-}
+space = {...NO_SPACE, bottom: true};
+export const OverflowOnlySpaceBelow: Story = {
+    args: {
+        mode: TOOLTIP_MODE.rightWithArrowMid,
+        pointTo: POINTS_TO.start,
+        space: space,
+    },
+    render: OverflowNoSpaceAbove.render,
+    decorators: getDecorator(space),
+};
 
-export const TopRightCenter = Template.bind({});
-TopRightCenter.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.topRight,
-    pos: TOOLTIP_POS.center,
-}
+space = {...NO_SPACE, left: true};
+export const OverflowOnlySpaceLeft: Story = {
+    args: {
+        mode: TOOLTIP_MODE.aboveWithArrowRight,
+        pointTo: POINTS_TO.end,
+        space: space,
+    },
+    render: OverflowNoSpaceAbove.render,
+    decorators: getDecorator(space),
+};
 
-// export const TopRightEnd = Template.bind({});
-// TopRightEnd.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.topRight,
-//     pos: TOOLTIP_POS.end,
-// }
+space = {...NO_SPACE, right: true};
+export const OverflowOnlySpaceRight: Story = {
+    args: {
+        mode: TOOLTIP_MODE.leftWithArrowMid,
+        pointTo: POINTS_TO.center,
+        space: space,
+    },
+    render: OverflowNoSpaceAbove.render,
+    decorators: getDecorator(space),
+};
 
-// export const LeftStart = Template.bind({});
-// LeftStart.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.left,
-//     pos: TOOLTIP_POS.start,
-// }
-
-export const LeftCenter = Template.bind({});
-LeftCenter.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.left,
-    pos: TOOLTIP_POS.center,
-}
-
-export const LeftEnd = Template.bind({});
-LeftEnd.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.left,
-    pos: TOOLTIP_POS.end,
-}
-
-// export const RightStart = Template.bind({});
-// RightStart.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.right,
-//     pos: TOOLTIP_POS.start,
-// }
-
-export const RightCenter = Template.bind({});
-RightCenter.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.right,
-    pos: TOOLTIP_POS.center,
-}
-
-export const RightEnd = Template.bind({});
-RightEnd.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.right,
-    pos: TOOLTIP_POS.end,
-}
+space = NO_SPACE;
+export const OverflowNoSpace: Story = {
+    args: {
+        mode: TOOLTIP_MODE.aboveWithArrowLeft,
+        pointTo: POINTS_TO.start,
+        space: space,
+    },
+    render: OverflowNoSpaceAbove.render,
+    decorators: getDecorator(space),
+};

--- a/components/TooltipWrapper.stories.tsx
+++ b/components/TooltipWrapper.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import TooltipWrapper, { TOOLTIP_POSITION } from './TooltipWrapper';
+import TooltipWrapper from './TooltipWrapper';
+import { TOOLTIP_POS } from './TooltipPositioned';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import { TOOLTIP_ARROW_POSITION } from './Tooltip';
@@ -16,12 +17,12 @@ export default {
     title: 'UI Kit/TooltipWrapper',
     component: TooltipWrapper,
     args: {
-        text: WALL,
+        text: TEXT,
         lockVisible: true,
     },
     decorators: [
             (Story) => (
-              <div style={{ margin: '10em' }}>
+              <div style={{ margin: '10rem 0 0 10rem' }}>
                 <Story />
               </div>
             ),
@@ -65,140 +66,192 @@ DefaultFunctional.args = {
     lockVisible: false
 }
 
-export const TopLeft = Template.bind({});
-TopLeft.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.topLeft,
-}
-
-export const TopRight = Template.bind({});
-TopRight.args = {
-    arrowPos: TOOLTIP_ARROW_POSITION.topRight,
-}
-
-export const BottomLeft = Template.bind({});
-BottomLeft.args = {
+export const AboveLeft = Template.bind({});
+AboveLeft.args = {
     arrowPos: TOOLTIP_ARROW_POSITION.bottomLeft,
 }
 
-export const BottomRight = Template.bind({});
-BottomRight.args = {
+export const AboveRight = Template.bind({});
+AboveRight.args = {
     arrowPos: TOOLTIP_ARROW_POSITION.bottomRight,
 }
 
-export const Left = Template.bind({});
-Left.args = {
+export const BelowLeft = Template.bind({});
+BelowLeft.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.topLeft,
+}
+
+export const BelowRight = Template.bind({});
+BelowRight.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.topRight,
+}
+
+export const OnRight = Template.bind({});
+OnRight.args = {
     arrowPos: TOOLTIP_ARROW_POSITION.left,
 }
 
-export const Right = Template.bind({});
-Right.args = {
+export const OnLeft = Template.bind({});
+OnLeft.args = {
     arrowPos: TOOLTIP_ARROW_POSITION.right,
 }
 
-// export const TopLeftStart = Template.bind({});
-// TopLeftStart.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.topLeft,
-//     pos: TOOLTIP_POSITION.start,
+/* 
+    Story with a full-width tooltip. Manually resizing the window allows you to check 
+    exactly when it repositions. Not much use in automated testing though: it doesn't 
+    force an overflow.
+*/
+// export const ManualOverflowTest = Template.bind({});
+// ManualOverflowTest.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.left,
+//     text: FULL_ROW,
 // }
 
-// export const TopLeftCenter = Template.bind({});
-// TopLeftCenter.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.topLeft,
-//     pos: TOOLTIP_POSITION.center,
-// }
+export const OverflowOnLeft = Template.bind({});
+OverflowOnLeft.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.right,
+    text: FULL_ROW,
+}
 
-// export const TopLeftEnd = Template.bind({});
-// TopLeftEnd.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.topLeft,
-//     pos: TOOLTIP_POSITION.end,
-// }
+export const OverflowOnRightPrefSideFits = Template.bind({});
+OverflowOnRightPrefSideFits .args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.left,
+    text: TEXT + TEXT,
+}
+OverflowOnRightPrefSideFits .parameters = {
+    viewport: {
+        defaultViewport: 'test_tooltipWrapper_onRight_prefSide',
+    }
+}
 
-// export const TopRightStart = Template.bind({});
-// TopRightStart.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.topRight,
-//     pos: TOOLTIP_POSITION.start,
-// }
+export const OverflowOnRight = Template.bind({});
+OverflowOnRight.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.left,
+    text: FULL_ROW,
+}
+OverflowOnRight.parameters = {
+    viewport: {
+        defaultViewport: 'test_tooltipWrapper_onRight',
+    }
+}
 
-// export const TopRightCenter = Template.bind({});
-// TopRightCenter.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.topRight,
-//     pos: TOOLTIP_POSITION.center,
-// }
+export const OverflowFullscreen = Template.bind({});
+OverflowFullscreen.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.left,
+    text: WALL,
+}
+OverflowFullscreen.parameters = {
+    viewport: {
+      defaultViewport: 'iphone5',
+    },
+};
 
-// export const TopRightEnd = Template.bind({});
-// TopRightEnd.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.topRight,
-//     pos: TOOLTIP_POSITION.end,
-// }
+
 
 // export const BottomLeftStart = Template.bind({});
 // BottomLeftStart.args = {
 //     arrowPos: TOOLTIP_ARROW_POSITION.bottomLeft,
-//     pos: TOOLTIP_POSITION.start,
+//     pos: TOOLTIP_POS.start,
 // }
 
-// export const BottomLeftCenter = Template.bind({});
-// BottomLeftCenter.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.bottomLeft,
-//     pos: TOOLTIP_POSITION.center,
-// }
+export const BottomLeftCenter = Template.bind({});
+BottomLeftCenter.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.bottomLeft,
+    pos: TOOLTIP_POS.center,
+}
 
-// export const BottomLeftEnd = Template.bind({});
-// BottomLeftEnd.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.bottomLeft,
-//     pos: TOOLTIP_POSITION.end,
-// }
+export const BottomLeftEnd = Template.bind({});
+BottomLeftEnd.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.bottomLeft,
+    pos: TOOLTIP_POS.end,
+}
 
-// export const BottomRightStart = Template.bind({});
-// BottomRightStart.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.bottomRight,
-//     pos: TOOLTIP_POSITION.start,
-// }
+export const BottomRightStart = Template.bind({});
+BottomRightStart.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.bottomRight,
+    pos: TOOLTIP_POS.start,
+}
 
-// export const BottomRightCenter = Template.bind({});
-// BottomRightCenter.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.bottomRight,
-//     pos: TOOLTIP_POSITION.center,
-// }
+export const BottomRightCenter = Template.bind({});
+BottomRightCenter.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.bottomRight,
+    pos: TOOLTIP_POS.center,
+}
 
 // export const BottomRightEnd = Template.bind({});
 // BottomRightEnd.args = {
 //     arrowPos: TOOLTIP_ARROW_POSITION.bottomRight,
-//     pos: TOOLTIP_POSITION.end,
+//     pos: TOOLTIP_POS.end,
+// }
+
+// export const TopLeftStart = Template.bind({});
+// TopLeftStart.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.topLeft,
+//     pos: TOOLTIP_POS.start,
+// }
+
+export const TopLeftCenter = Template.bind({});
+TopLeftCenter.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.topLeft,
+    pos: TOOLTIP_POS.center,
+}
+
+export const TopLeftEnd = Template.bind({});
+TopLeftEnd.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.topLeft,
+    pos: TOOLTIP_POS.end,
+}
+
+export const TopRightStart = Template.bind({});
+TopRightStart.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.topRight,
+    pos: TOOLTIP_POS.start,
+}
+
+export const TopRightCenter = Template.bind({});
+TopRightCenter.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.topRight,
+    pos: TOOLTIP_POS.center,
+}
+
+// export const TopRightEnd = Template.bind({});
+// TopRightEnd.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.topRight,
+//     pos: TOOLTIP_POS.end,
 // }
 
 // export const LeftStart = Template.bind({});
 // LeftStart.args = {
 //     arrowPos: TOOLTIP_ARROW_POSITION.left,
-//     pos: TOOLTIP_POSITION.start,
+//     pos: TOOLTIP_POS.start,
 // }
 
-// export const LeftCenter = Template.bind({});
-// LeftCenter.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.left,
-//     pos: TOOLTIP_POSITION.center,
-// }
+export const LeftCenter = Template.bind({});
+LeftCenter.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.left,
+    pos: TOOLTIP_POS.center,
+}
 
-// export const LeftEnd = Template.bind({});
-// LeftEnd.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.left,
-//     pos: TOOLTIP_POSITION.end,
-// }
+export const LeftEnd = Template.bind({});
+LeftEnd.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.left,
+    pos: TOOLTIP_POS.end,
+}
 
 // export const RightStart = Template.bind({});
 // RightStart.args = {
 //     arrowPos: TOOLTIP_ARROW_POSITION.right,
-//     pos: TOOLTIP_POSITION.start,
+//     pos: TOOLTIP_POS.start,
 // }
 
-// export const RightCenter = Template.bind({});
-// RightCenter.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.right,
-//     pos: TOOLTIP_POSITION.center,
-// }
+export const RightCenter = Template.bind({});
+RightCenter.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.right,
+    pos: TOOLTIP_POS.center,
+}
 
-// export const RightEnd = Template.bind({});
-// RightEnd.args = {
-//     arrowPos: TOOLTIP_ARROW_POSITION.right,
-//     pos: TOOLTIP_POSITION.end,
-// }
+export const RightEnd = Template.bind({});
+RightEnd.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.right,
+    pos: TOOLTIP_POS.end,
+}

--- a/components/TooltipWrapper.stories.tsx
+++ b/components/TooltipWrapper.stories.tsx
@@ -1,0 +1,204 @@
+import React from 'react';
+import TooltipWrapper, { TOOLTIP_POSITION } from './TooltipWrapper';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { TOOLTIP_ARROW_POSITION } from './Tooltip';
+import styled from 'styled-components';
+import { PALETTE, TYPOGRAPHY } from '../utils/Theme';
+
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+const TEXT = "Your Text in Tooltip ";
+const FULL_ROW = TEXT + TEXT + TEXT;
+const THREE_ROWS = FULL_ROW + FULL_ROW + FULL_ROW;
+const WALL = THREE_ROWS + THREE_ROWS + THREE_ROWS;
+
+export default {
+    title: 'UI Kit/TooltipWrapper',
+    component: TooltipWrapper,
+    args: {
+        text: WALL,
+        lockVisible: true,
+    },
+    decorators: [
+            (Story) => (
+              <div style={{ margin: '10em' }}>
+                <Story />
+              </div>
+            ),
+    ],
+  } as ComponentMeta<typeof TooltipWrapper>;
+
+const StyledBox = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 10rem;
+    height: 4rem;
+    background: ${PALETTE.primary};
+    padding: 1rem;
+  
+    span{
+        ${TYPOGRAPHY.p2}
+        color: ${PALETTE.white};
+        text-align: center;
+    }
+`;
+
+const FunctioningTemplate: ComponentStory<typeof TooltipWrapper> = args => {
+    return  <TooltipWrapper {...args}>
+                <StyledBox>
+                    <span>Hover, focus or tap me :)</span>
+                </StyledBox>
+            </TooltipWrapper>
+}
+
+const Template: ComponentStory<typeof TooltipWrapper> = args => {
+    return  <TooltipWrapper {...args}>
+                <StyledBox>
+                    <span>Tooltip target</span>
+                </StyledBox>
+            </TooltipWrapper>
+}
+
+export const DefaultFunctional = FunctioningTemplate.bind({});
+DefaultFunctional.args = {
+    lockVisible: false
+}
+
+export const TopLeft = Template.bind({});
+TopLeft.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.topLeft,
+}
+
+export const TopRight = Template.bind({});
+TopRight.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.topRight,
+}
+
+export const BottomLeft = Template.bind({});
+BottomLeft.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.bottomLeft,
+}
+
+export const BottomRight = Template.bind({});
+BottomRight.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.bottomRight,
+}
+
+export const Left = Template.bind({});
+Left.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.left,
+}
+
+export const Right = Template.bind({});
+Right.args = {
+    arrowPos: TOOLTIP_ARROW_POSITION.right,
+}
+
+// export const TopLeftStart = Template.bind({});
+// TopLeftStart.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.topLeft,
+//     pos: TOOLTIP_POSITION.start,
+// }
+
+// export const TopLeftCenter = Template.bind({});
+// TopLeftCenter.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.topLeft,
+//     pos: TOOLTIP_POSITION.center,
+// }
+
+// export const TopLeftEnd = Template.bind({});
+// TopLeftEnd.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.topLeft,
+//     pos: TOOLTIP_POSITION.end,
+// }
+
+// export const TopRightStart = Template.bind({});
+// TopRightStart.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.topRight,
+//     pos: TOOLTIP_POSITION.start,
+// }
+
+// export const TopRightCenter = Template.bind({});
+// TopRightCenter.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.topRight,
+//     pos: TOOLTIP_POSITION.center,
+// }
+
+// export const TopRightEnd = Template.bind({});
+// TopRightEnd.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.topRight,
+//     pos: TOOLTIP_POSITION.end,
+// }
+
+// export const BottomLeftStart = Template.bind({});
+// BottomLeftStart.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.bottomLeft,
+//     pos: TOOLTIP_POSITION.start,
+// }
+
+// export const BottomLeftCenter = Template.bind({});
+// BottomLeftCenter.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.bottomLeft,
+//     pos: TOOLTIP_POSITION.center,
+// }
+
+// export const BottomLeftEnd = Template.bind({});
+// BottomLeftEnd.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.bottomLeft,
+//     pos: TOOLTIP_POSITION.end,
+// }
+
+// export const BottomRightStart = Template.bind({});
+// BottomRightStart.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.bottomRight,
+//     pos: TOOLTIP_POSITION.start,
+// }
+
+// export const BottomRightCenter = Template.bind({});
+// BottomRightCenter.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.bottomRight,
+//     pos: TOOLTIP_POSITION.center,
+// }
+
+// export const BottomRightEnd = Template.bind({});
+// BottomRightEnd.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.bottomRight,
+//     pos: TOOLTIP_POSITION.end,
+// }
+
+// export const LeftStart = Template.bind({});
+// LeftStart.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.left,
+//     pos: TOOLTIP_POSITION.start,
+// }
+
+// export const LeftCenter = Template.bind({});
+// LeftCenter.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.left,
+//     pos: TOOLTIP_POSITION.center,
+// }
+
+// export const LeftEnd = Template.bind({});
+// LeftEnd.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.left,
+//     pos: TOOLTIP_POSITION.end,
+// }
+
+// export const RightStart = Template.bind({});
+// RightStart.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.right,
+//     pos: TOOLTIP_POSITION.start,
+// }
+
+// export const RightCenter = Template.bind({});
+// RightCenter.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.right,
+//     pos: TOOLTIP_POSITION.center,
+// }
+
+// export const RightEnd = Template.bind({});
+// RightEnd.args = {
+//     arrowPos: TOOLTIP_ARROW_POSITION.right,
+//     pos: TOOLTIP_POSITION.end,
+// }

--- a/components/TooltipWrapper.tsx
+++ b/components/TooltipWrapper.tsx
@@ -1,0 +1,390 @@
+import React from 'react';
+import styled, {css} from 'styled-components';
+import { visuallyHidden, visuallyUnhidden } from '../utils/utils';
+import Tooltip, {I_TooltipProps, TOOLTIP_ARROW_POSITION} from './Tooltip';
+
+export enum TOOLTIP_POSITION{
+    start = "start",
+    center = "center",
+    end = "end"
+}
+
+// For topX and bottomX arrows: the distance between the edge of the tooltip and the arrow point.
+// Use this offset to adjust tooltip positioning so it relates to the arrow point (rather than the edge).
+const ARROW_OFFSET = "1.375rem"; 
+
+// Start and end settings don't look right if they point to the very first pixel of the target element.
+// Move them "in a bit" instead.
+const EDGE_OFFSET = "0.6875rem";
+
+// Move the tooltip so it's exactly next to the edge of the target element: then move it just a little 
+// bit more, to leave space for the arrow and a tiny gap.
+const NEXT_TO_TARGET = "calc(100% + 0.4375rem)";
+
+
+
+type TooltipWrapperProps = {
+    arrowPos? : TOOLTIP_ARROW_POSITION,
+    availableWidth : number,
+    perpPos? : TOOLTIP_POSITION,  
+    tooltipIsVisible : boolean
+    dimensions: { width : number, height : number },
+}
+
+type TooltipWrapperAttrsOutput = {
+    style : {
+        top: string,
+        right: string,
+        bottom: string,
+        left : string,
+        maxWidth : string,
+    },
+}
+
+const StyledTooltipContainer = styled.div.attrs<
+        TooltipWrapperProps,
+        TooltipWrapperAttrsOutput
+    >((props : TooltipWrapperProps) => {
+        const pos = getPositioningSettings({perpPos: props.perpPos, arrowPos: props.arrowPos, dimensions : props.dimensions});
+        return {
+            style: {
+                    top: pos ? pos.top : "0",
+                    right: pos ? pos.right : "0",
+                    bottom: pos ? pos.bottom : "0",
+                    left: pos ? pos.left : "0",
+                    maxWidth: `min(25rem, ${props.availableWidth}px)`,
+                },
+        }
+    })<TooltipWrapperProps>`
+
+    display: block;
+    position: absolute;
+    z-index: 5;
+    width: max-content;
+
+    ${props => {
+        if(!props.tooltipIsVisible){
+            return visuallyHidden;
+        }
+    }}
+`;
+
+const StyledWrapper = styled.div`
+    width: fit-content;
+    height: fit-content;
+
+    position: relative;
+`;
+
+// This works, but also apparently generates a gazillion classes (if the window is resized a lot)
+// const StyledWrapper = styled.div<TooltipWrapperProps>`
+//     width: fit-content;
+//     height: fit-content;
+
+//     position: relative;
+//     ${props => {
+//         if(!props.tooltipIsVisible){
+//             return;
+//         }
+//         return css`${StyledTooltipContainer}{
+//             ${visuallyUnhidden}
+//             display: block;
+//             position: absolute;
+//             z-index: 5;
+    
+//             width: max-content;
+//             max-width: ${props.availableWidth >= props.dimensions.width ? "25rem" : `${props.availableWidth}px`};
+            
+//             ${getPositioningCss({perpPos: props.perpPos, arrowPos: props.arrowPos, dimensions : props.dimensions})};
+//         }`
+//     }}
+
+// `;
+
+
+// function getPositioningCss({perpPos, arrowPos, dimensions} : Pick<TooltipWrapperProps, "arrowPos" | "dimensions" | "perpPos">){
+//     let offsetSize : string;
+
+//     switch(arrowPos){
+
+//         case TOOLTIP_ARROW_POSITION.bottomLeft:
+//             perpPos = perpPos ?? TOOLTIP_POSITION.start;
+//             offsetSize = getPerpendicularX(perpPos, false);
+//             return css`
+//                 bottom: ${NEXT_TO_TARGET};
+//                 left: ${offsetSize};
+//             `;
+
+//         case TOOLTIP_ARROW_POSITION.bottomRight:
+//             perpPos = perpPos ?? TOOLTIP_POSITION.end;
+//             offsetSize = getPerpendicularX(perpPos, true);
+//             return css`
+//                 bottom: ${NEXT_TO_TARGET};
+//                 right: ${offsetSize};
+//             `;
+
+//         case TOOLTIP_ARROW_POSITION.left:
+//             perpPos = perpPos ?? TOOLTIP_POSITION.start;
+//             offsetSize = getPerpendicularY(perpPos, dimensions.height);
+//             return css`
+//                 top: ${offsetSize};
+//                 left: ${NEXT_TO_TARGET};
+//             `;
+
+//         case TOOLTIP_ARROW_POSITION.topLeft:
+//             perpPos = perpPos ?? TOOLTIP_POSITION.start;
+//             offsetSize = getPerpendicularX(perpPos, false);
+//             return css`
+//                 top: ${NEXT_TO_TARGET};
+//                 left: ${offsetSize};
+//             `;
+
+//         case TOOLTIP_ARROW_POSITION.topRight:
+//             perpPos = perpPos ?? TOOLTIP_POSITION.end;
+//             offsetSize = getPerpendicularX(perpPos, true);
+//             return css`
+//                 top: ${NEXT_TO_TARGET};
+//                 right: ${offsetSize};
+//             `;
+
+//         case TOOLTIP_ARROW_POSITION.right:
+//             perpPos = perpPos ?? TOOLTIP_POSITION.start;
+//             offsetSize = getPerpendicularY(perpPos, dimensions.height);
+//             return css`
+//                 top: ${offsetSize};
+//                 right: ${NEXT_TO_TARGET};
+//             `;
+
+//         default:
+//             return null;
+//     }
+// }
+
+function getPositioningSettings({perpPos, arrowPos, dimensions} : Pick<TooltipWrapperProps, "arrowPos" | "dimensions" | "perpPos">){
+    switch(arrowPos){
+
+        case TOOLTIP_ARROW_POSITION.bottomLeft:
+            perpPos = perpPos ?? TOOLTIP_POSITION.start;
+            return {
+                top: "auto",
+                right: "auto",
+                bottom: NEXT_TO_TARGET,
+                left: getPerpendicularX(perpPos, false),
+            }
+
+        case TOOLTIP_ARROW_POSITION.bottomRight:
+            perpPos = perpPos ?? TOOLTIP_POSITION.end;
+            return {
+                top: "auto",
+                right: getPerpendicularX(perpPos, true),
+                bottom: NEXT_TO_TARGET,
+                left: "auto",
+            }
+
+        case TOOLTIP_ARROW_POSITION.left:
+            perpPos = perpPos ?? TOOLTIP_POSITION.start;
+            return {
+                top: getPerpendicularY(perpPos, dimensions.height),
+                right: "auto",
+                bottom: "auto",
+                left: NEXT_TO_TARGET,
+            }
+
+        case TOOLTIP_ARROW_POSITION.topLeft:
+            perpPos = perpPos ?? TOOLTIP_POSITION.start;
+            return {
+                top: NEXT_TO_TARGET,
+                right: "auto",
+                bottom: "auto",
+                left: getPerpendicularX(perpPos, false),
+            }
+
+        case TOOLTIP_ARROW_POSITION.topRight:
+            perpPos = perpPos ?? TOOLTIP_POSITION.end;
+            return {
+                top: NEXT_TO_TARGET,
+                right: getPerpendicularX(perpPos, true),
+                bottom: "auto",
+                left: "auto",
+            }
+
+        case TOOLTIP_ARROW_POSITION.right:
+            perpPos = perpPos ?? TOOLTIP_POSITION.start;
+            return {
+                top: getPerpendicularY(perpPos, dimensions.height),
+                right: NEXT_TO_TARGET,
+                bottom: "auto",
+                left: "auto",
+            }
+
+        default:
+            return null;
+    }
+}
+
+function getPerpendicularX(pos : TOOLTIP_POSITION, fromRight : boolean){
+    /*  As more tooltip content is added, tooltips with arrows in topX and bottomX 
+        positions should keep the arrow locked in position and "grow" in width on 
+        the side lacking the arrow.
+        If the wrapper is positioned relative to the arrow-side, there's no need to 
+        take the width of the tooltip into account: simply reverse the start and 
+        end values when "right: ...;" is used.
+    */
+
+    const NEGATIVE_EDGE_OFFSET = `-${EDGE_OFFSET}`;
+    const EDGE_OFFSET_FROM_OPPOSITE = `calc(100% - ${ARROW_OFFSET} - ${EDGE_OFFSET})`;
+
+    switch(pos){
+        case TOOLTIP_POSITION.start:
+            return fromRight ? EDGE_OFFSET_FROM_OPPOSITE : NEGATIVE_EDGE_OFFSET;
+        case TOOLTIP_POSITION.end:
+            return fromRight ? NEGATIVE_EDGE_OFFSET : EDGE_OFFSET_FROM_OPPOSITE;
+        case TOOLTIP_POSITION.center:
+            return `calc(50% - ${ARROW_OFFSET})`;
+        default:
+            return NEGATIVE_EDGE_OFFSET;
+    }
+}
+
+function getPerpendicularY(pos : TOOLTIP_POSITION, heightInPx : number){
+    /*  As more tooltip content is added, tooltips with arrows in left and right
+        positions should keep the arrow locked in position and "grow" in height
+        equally on both sides of the arrow.
+        This means taking the height into account.
+    */
+
+    const HEIGHT_OFFSET = `${heightInPx / 2}px`;
+
+    switch(pos){
+        case TOOLTIP_POSITION.start:
+            return `calc(${EDGE_OFFSET} - ${HEIGHT_OFFSET})`;
+        case TOOLTIP_POSITION.end:
+            return `calc(100% - ${EDGE_OFFSET} - ${HEIGHT_OFFSET})`;
+        case TOOLTIP_POSITION.center:
+            return `calc(50% - ${HEIGHT_OFFSET})`;
+        default:
+            return `calc(${EDGE_OFFSET} - ${HEIGHT_OFFSET})`;
+    }
+}
+
+interface I_TooltipWrapper extends I_TooltipProps{
+    className?: string,
+    pos? : TOOLTIP_POSITION,
+    lockVisible? : boolean,
+    children: React.ReactNode,
+}
+import useCloseOnOutsideClick from '../utils/UseCloseOnOutsideClick';
+export default function TooltipWrapper({lockVisible, className, pos, text, arrowPos, children} : I_TooltipWrapper){
+    const [isVisible, setIsVisible] = React.useState(false);
+
+    const refWrapper = React.useRef<HTMLDivElement | null>(null);
+    const refTooltip = React.useRef<HTMLDivElement | null>(null);
+    const tooltipSize = useDimensions(refTooltip);
+
+    // Set a default arrowPos if one has not been provided. This will set a default pos
+    const arrowDir = arrowPos ?? TOOLTIP_ARROW_POSITION.bottomLeft;
+
+    function availableWidth() : number{
+        const paddingPx = 8;
+        let screenWidth = window.innerWidth;
+
+        if(refTooltip && refTooltip.current){ 
+            let rectTooltip = refTooltip.current.getBoundingClientRect();
+
+            // Arrow on the right = determine available space to the left
+            if(    arrowDir === TOOLTIP_ARROW_POSITION.bottomRight
+                || arrowDir === TOOLTIP_ARROW_POSITION.topRight
+                || arrowDir === TOOLTIP_ARROW_POSITION.right
+              )
+            {
+                return rectTooltip.right - paddingPx;
+            }
+            // Arrow on the left = determine available space to the right
+            else{
+                return screenWidth - rectTooltip.left - paddingPx;
+            }
+        }
+
+        return screenWidth - (paddingPx * 2);
+    }
+
+    // For touchscreen users
+    useCloseOnOutsideClick({
+        isOpen : isVisible, 
+        containerEle : refWrapper.current,
+        setIsOpen : setIsVisible
+    });
+
+    function handleClick(){
+        setIsVisible(prevState =>{
+            return !prevState
+        });
+    }
+
+    // For keyboard users
+    function handleKeydown(e : React.KeyboardEvent){
+        if(e.key === "Escape"){
+            setIsVisible(false);
+        }
+    }
+
+    const id = React.useId();
+    return  <StyledWrapper  ref={refWrapper}
+                            aria-describedby={id}
+                            className={className} 
+                            tabIndex={0} 
+                            onClick={() => handleClick()} 
+                            onBlur={() => setIsVisible(false)}
+                            onFocus={() => setIsVisible(true)}
+                            onKeyDown={(e) => handleKeydown(e)}
+                            onMouseOut={() => setIsVisible(false)}
+                            onMouseOver={() => setIsVisible(true)} 
+                            >
+                {children}
+                <StyledTooltipContainer     ref={refTooltip} 
+                                            arrowPos={arrowDir} 
+                                            availableWidth={availableWidth()}
+                                            dimensions={tooltipSize}  
+                                            perpPos={pos} 
+                                            tooltipIsVisible={lockVisible || isVisible} 
+                                            >
+                    <Tooltip id={id} text={text} arrowPos={arrowPos} />
+                </StyledTooltipContainer>
+            </StyledWrapper>
+}
+
+// type TooltipWrapperProps = {
+//     arrowPos? : TOOLTIP_ARROW_POSITION,
+//     availableWidth : number,
+//     perpPos? : TOOLTIP_POSITION,  
+//     tooltipIsVisible : boolean
+//     dimensions: { width : number, height : number },
+// }
+
+function useDimensions(targetRef : React.MutableRefObject<HTMLDivElement | null>) {
+    function getDimensions(){
+        return {
+            width: targetRef.current ? targetRef.current.offsetWidth : 0,
+            height: targetRef.current ? targetRef.current.offsetHeight : 0
+        };
+    };
+
+    const [dimensions, setDimensions] = React.useState(getDimensions);
+
+    function handleResize(){
+        setDimensions(getDimensions());
+    };
+
+    React.useEffect(() => {
+        window.addEventListener("resize", handleResize);
+        return () => window.removeEventListener("resize", handleResize);
+    }, []);
+
+    React.useLayoutEffect(() => {
+        handleResize();
+    }, []);
+
+    return dimensions;
+  }
+
+

--- a/components/TooltipWrapper.tsx
+++ b/components/TooltipWrapper.tsx
@@ -5,7 +5,8 @@ import React from 'react';
 import styled from 'styled-components';
 import {I_TooltipProps} from './Tooltip';
 import useCloseOnOutsideClick from '../utils/UseCloseOnOutsideClick';
-import TooltipPositioned, { TOOLTIP_POS } from './TooltipPositioned';
+import TooltipPositioned, { T_TooltipPositionedProps } from './TooltipPositioned';
+
 
 const StyledWrapper = styled.div`
     height: fit-content;
@@ -13,17 +14,24 @@ const StyledWrapper = styled.div`
     width: fit-content;
 `;
 
-type TooltipWrapperProps = Pick<I_TooltipProps, "arrowPos" | "text"> & {
-    className?: string,
-    pos? : TOOLTIP_POS,
-    lockVisible? : boolean,
-    children: React.ReactNode,
+
+type TooltipWrapperProps = 
+    Pick<I_TooltipProps, "text"> 
+    & Pick<T_TooltipPositionedProps, "mode" | "pointTo"> 
+    &{
+        className?: string,
+        lockVisible? : boolean,         /* true = tooltip is permanently visible */
+        children: React.ReactNode,
 }
 
-export default function TooltipWrapper({lockVisible, className, pos, text, arrowPos, children} : TooltipWrapperProps){
+
+export default function TooltipWrapper({mode, lockVisible, pointTo, text, className, children} 
+    : TooltipWrapperProps)
+    {
+
     const [isVisible, setIsVisible] = React.useState(false);
     const ref = React.useRef(null);
-    const wrapperPos = useXPosition(ref);
+    const wrapperPos = usePosition(ref); /* Used to prevent the tooltip from going off screen */
     
     // For touchscreen users
     useCloseOnOutsideClick({
@@ -59,9 +67,9 @@ export default function TooltipWrapper({lockVisible, className, pos, text, arrow
                             >
                 {children}
             {lockVisible || isVisible ? 
-                <TooltipPositioned  arrowPos={arrowPos} 
+                <TooltipPositioned  mode={mode} 
                                     id={id}
-                                    pos={pos} 
+                                    pointTo={pointTo} 
                                     text={text} 
                                     wrapperPos={wrapperPos}
                 />
@@ -70,13 +78,14 @@ export default function TooltipWrapper({lockVisible, className, pos, text, arrow
             </StyledWrapper>
 }
 
+
 export type PositionsObj = {
     left : number,
     right : number,
     top : number,
     bottom : number,
 }
- function useXPosition(ref : React.MutableRefObject<HTMLDivElement | null>) : PositionsObj{
+ function usePosition(ref : React.MutableRefObject<HTMLDivElement | null>) : PositionsObj{
     const [positions, setPositions] = React.useState(getPositions);
 
     function getPositions(){

--- a/components/TooltipWrapper.tsx
+++ b/components/TooltipWrapper.tsx
@@ -1,317 +1,34 @@
+/*
+    Wrapper component to place around the element which wants a tooltip.
+*/
 import React from 'react';
-import styled, {css} from 'styled-components';
-import { visuallyHidden, visuallyUnhidden } from '../utils/utils';
-import Tooltip, {I_TooltipProps, TOOLTIP_ARROW_POSITION} from './Tooltip';
-
-export enum TOOLTIP_POSITION{
-    start = "start",
-    center = "center",
-    end = "end"
-}
-
-// For topX and bottomX arrows: the distance between the edge of the tooltip and the arrow point.
-// Use this offset to adjust tooltip positioning so it relates to the arrow point (rather than the edge).
-const ARROW_OFFSET = "1.375rem"; 
-
-// Start and end settings don't look right if they point to the very first pixel of the target element.
-// Move them "in a bit" instead.
-const EDGE_OFFSET = "0.6875rem";
-
-// Move the tooltip so it's exactly next to the edge of the target element: then move it just a little 
-// bit more, to leave space for the arrow and a tiny gap.
-const NEXT_TO_TARGET = "calc(100% + 0.4375rem)";
-
-
-
-type TooltipWrapperProps = {
-    arrowPos? : TOOLTIP_ARROW_POSITION,
-    availableWidth : number,
-    perpPos? : TOOLTIP_POSITION,  
-    tooltipIsVisible : boolean
-    dimensions: { width : number, height : number },
-}
-
-type TooltipWrapperAttrsOutput = {
-    style : {
-        top: string,
-        right: string,
-        bottom: string,
-        left : string,
-        maxWidth : string,
-    },
-}
-
-const StyledTooltipContainer = styled.div.attrs<
-        TooltipWrapperProps,
-        TooltipWrapperAttrsOutput
-    >((props : TooltipWrapperProps) => {
-        const pos = getPositioningSettings({perpPos: props.perpPos, arrowPos: props.arrowPos, dimensions : props.dimensions});
-        return {
-            style: {
-                    top: pos ? pos.top : "0",
-                    right: pos ? pos.right : "0",
-                    bottom: pos ? pos.bottom : "0",
-                    left: pos ? pos.left : "0",
-                    maxWidth: `min(25rem, ${props.availableWidth}px)`,
-                },
-        }
-    })<TooltipWrapperProps>`
-
-    display: block;
-    position: absolute;
-    z-index: 5;
-    width: max-content;
-
-    ${props => {
-        if(!props.tooltipIsVisible){
-            return visuallyHidden;
-        }
-    }}
-`;
+import styled from 'styled-components';
+import {I_TooltipProps} from './Tooltip';
+import useCloseOnOutsideClick from '../utils/UseCloseOnOutsideClick';
+import TooltipPositioned, { TOOLTIP_POS } from './TooltipPositioned';
 
 const StyledWrapper = styled.div`
-    width: fit-content;
     height: fit-content;
-
     position: relative;
+    width: fit-content;
 `;
 
-// This works, but also apparently generates a gazillion classes (if the window is resized a lot)
-// const StyledWrapper = styled.div<TooltipWrapperProps>`
-//     width: fit-content;
-//     height: fit-content;
-
-//     position: relative;
-//     ${props => {
-//         if(!props.tooltipIsVisible){
-//             return;
-//         }
-//         return css`${StyledTooltipContainer}{
-//             ${visuallyUnhidden}
-//             display: block;
-//             position: absolute;
-//             z-index: 5;
-    
-//             width: max-content;
-//             max-width: ${props.availableWidth >= props.dimensions.width ? "25rem" : `${props.availableWidth}px`};
-            
-//             ${getPositioningCss({perpPos: props.perpPos, arrowPos: props.arrowPos, dimensions : props.dimensions})};
-//         }`
-//     }}
-
-// `;
-
-
-// function getPositioningCss({perpPos, arrowPos, dimensions} : Pick<TooltipWrapperProps, "arrowPos" | "dimensions" | "perpPos">){
-//     let offsetSize : string;
-
-//     switch(arrowPos){
-
-//         case TOOLTIP_ARROW_POSITION.bottomLeft:
-//             perpPos = perpPos ?? TOOLTIP_POSITION.start;
-//             offsetSize = getPerpendicularX(perpPos, false);
-//             return css`
-//                 bottom: ${NEXT_TO_TARGET};
-//                 left: ${offsetSize};
-//             `;
-
-//         case TOOLTIP_ARROW_POSITION.bottomRight:
-//             perpPos = perpPos ?? TOOLTIP_POSITION.end;
-//             offsetSize = getPerpendicularX(perpPos, true);
-//             return css`
-//                 bottom: ${NEXT_TO_TARGET};
-//                 right: ${offsetSize};
-//             `;
-
-//         case TOOLTIP_ARROW_POSITION.left:
-//             perpPos = perpPos ?? TOOLTIP_POSITION.start;
-//             offsetSize = getPerpendicularY(perpPos, dimensions.height);
-//             return css`
-//                 top: ${offsetSize};
-//                 left: ${NEXT_TO_TARGET};
-//             `;
-
-//         case TOOLTIP_ARROW_POSITION.topLeft:
-//             perpPos = perpPos ?? TOOLTIP_POSITION.start;
-//             offsetSize = getPerpendicularX(perpPos, false);
-//             return css`
-//                 top: ${NEXT_TO_TARGET};
-//                 left: ${offsetSize};
-//             `;
-
-//         case TOOLTIP_ARROW_POSITION.topRight:
-//             perpPos = perpPos ?? TOOLTIP_POSITION.end;
-//             offsetSize = getPerpendicularX(perpPos, true);
-//             return css`
-//                 top: ${NEXT_TO_TARGET};
-//                 right: ${offsetSize};
-//             `;
-
-//         case TOOLTIP_ARROW_POSITION.right:
-//             perpPos = perpPos ?? TOOLTIP_POSITION.start;
-//             offsetSize = getPerpendicularY(perpPos, dimensions.height);
-//             return css`
-//                 top: ${offsetSize};
-//                 right: ${NEXT_TO_TARGET};
-//             `;
-
-//         default:
-//             return null;
-//     }
-// }
-
-function getPositioningSettings({perpPos, arrowPos, dimensions} : Pick<TooltipWrapperProps, "arrowPos" | "dimensions" | "perpPos">){
-    switch(arrowPos){
-
-        case TOOLTIP_ARROW_POSITION.bottomLeft:
-            perpPos = perpPos ?? TOOLTIP_POSITION.start;
-            return {
-                top: "auto",
-                right: "auto",
-                bottom: NEXT_TO_TARGET,
-                left: getPerpendicularX(perpPos, false),
-            }
-
-        case TOOLTIP_ARROW_POSITION.bottomRight:
-            perpPos = perpPos ?? TOOLTIP_POSITION.end;
-            return {
-                top: "auto",
-                right: getPerpendicularX(perpPos, true),
-                bottom: NEXT_TO_TARGET,
-                left: "auto",
-            }
-
-        case TOOLTIP_ARROW_POSITION.left:
-            perpPos = perpPos ?? TOOLTIP_POSITION.start;
-            return {
-                top: getPerpendicularY(perpPos, dimensions.height),
-                right: "auto",
-                bottom: "auto",
-                left: NEXT_TO_TARGET,
-            }
-
-        case TOOLTIP_ARROW_POSITION.topLeft:
-            perpPos = perpPos ?? TOOLTIP_POSITION.start;
-            return {
-                top: NEXT_TO_TARGET,
-                right: "auto",
-                bottom: "auto",
-                left: getPerpendicularX(perpPos, false),
-            }
-
-        case TOOLTIP_ARROW_POSITION.topRight:
-            perpPos = perpPos ?? TOOLTIP_POSITION.end;
-            return {
-                top: NEXT_TO_TARGET,
-                right: getPerpendicularX(perpPos, true),
-                bottom: "auto",
-                left: "auto",
-            }
-
-        case TOOLTIP_ARROW_POSITION.right:
-            perpPos = perpPos ?? TOOLTIP_POSITION.start;
-            return {
-                top: getPerpendicularY(perpPos, dimensions.height),
-                right: NEXT_TO_TARGET,
-                bottom: "auto",
-                left: "auto",
-            }
-
-        default:
-            return null;
-    }
-}
-
-function getPerpendicularX(pos : TOOLTIP_POSITION, fromRight : boolean){
-    /*  As more tooltip content is added, tooltips with arrows in topX and bottomX 
-        positions should keep the arrow locked in position and "grow" in width on 
-        the side lacking the arrow.
-        If the wrapper is positioned relative to the arrow-side, there's no need to 
-        take the width of the tooltip into account: simply reverse the start and 
-        end values when "right: ...;" is used.
-    */
-
-    const NEGATIVE_EDGE_OFFSET = `-${EDGE_OFFSET}`;
-    const EDGE_OFFSET_FROM_OPPOSITE = `calc(100% - ${ARROW_OFFSET} - ${EDGE_OFFSET})`;
-
-    switch(pos){
-        case TOOLTIP_POSITION.start:
-            return fromRight ? EDGE_OFFSET_FROM_OPPOSITE : NEGATIVE_EDGE_OFFSET;
-        case TOOLTIP_POSITION.end:
-            return fromRight ? NEGATIVE_EDGE_OFFSET : EDGE_OFFSET_FROM_OPPOSITE;
-        case TOOLTIP_POSITION.center:
-            return `calc(50% - ${ARROW_OFFSET})`;
-        default:
-            return NEGATIVE_EDGE_OFFSET;
-    }
-}
-
-function getPerpendicularY(pos : TOOLTIP_POSITION, heightInPx : number){
-    /*  As more tooltip content is added, tooltips with arrows in left and right
-        positions should keep the arrow locked in position and "grow" in height
-        equally on both sides of the arrow.
-        This means taking the height into account.
-    */
-
-    const HEIGHT_OFFSET = `${heightInPx / 2}px`;
-
-    switch(pos){
-        case TOOLTIP_POSITION.start:
-            return `calc(${EDGE_OFFSET} - ${HEIGHT_OFFSET})`;
-        case TOOLTIP_POSITION.end:
-            return `calc(100% - ${EDGE_OFFSET} - ${HEIGHT_OFFSET})`;
-        case TOOLTIP_POSITION.center:
-            return `calc(50% - ${HEIGHT_OFFSET})`;
-        default:
-            return `calc(${EDGE_OFFSET} - ${HEIGHT_OFFSET})`;
-    }
-}
-
-interface I_TooltipWrapper extends I_TooltipProps{
+type TooltipWrapperProps = Pick<I_TooltipProps, "arrowPos" | "text"> & {
     className?: string,
-    pos? : TOOLTIP_POSITION,
+    pos? : TOOLTIP_POS,
     lockVisible? : boolean,
     children: React.ReactNode,
 }
-import useCloseOnOutsideClick from '../utils/UseCloseOnOutsideClick';
-export default function TooltipWrapper({lockVisible, className, pos, text, arrowPos, children} : I_TooltipWrapper){
+
+export default function TooltipWrapper({lockVisible, className, pos, text, arrowPos, children} : TooltipWrapperProps){
     const [isVisible, setIsVisible] = React.useState(false);
-
-    const refWrapper = React.useRef<HTMLDivElement | null>(null);
-    const refTooltip = React.useRef<HTMLDivElement | null>(null);
-    const tooltipSize = useDimensions(refTooltip);
-
-    // Set a default arrowPos if one has not been provided. This will set a default pos
-    const arrowDir = arrowPos ?? TOOLTIP_ARROW_POSITION.bottomLeft;
-
-    function availableWidth() : number{
-        const paddingPx = 8;
-        let screenWidth = window.innerWidth;
-
-        if(refTooltip && refTooltip.current){ 
-            let rectTooltip = refTooltip.current.getBoundingClientRect();
-
-            // Arrow on the right = determine available space to the left
-            if(    arrowDir === TOOLTIP_ARROW_POSITION.bottomRight
-                || arrowDir === TOOLTIP_ARROW_POSITION.topRight
-                || arrowDir === TOOLTIP_ARROW_POSITION.right
-              )
-            {
-                return rectTooltip.right - paddingPx;
-            }
-            // Arrow on the left = determine available space to the right
-            else{
-                return screenWidth - rectTooltip.left - paddingPx;
-            }
-        }
-
-        return screenWidth - (paddingPx * 2);
-    }
-
+    const ref = React.useRef(null);
+    const wrapperPos = useXPosition(ref);
+    
     // For touchscreen users
     useCloseOnOutsideClick({
         isOpen : isVisible, 
-        containerEle : refWrapper.current,
+        containerEle : ref.current ? ref.current : null,
         setIsOpen : setIsVisible
     });
 
@@ -329,7 +46,7 @@ export default function TooltipWrapper({lockVisible, className, pos, text, arrow
     }
 
     const id = React.useId();
-    return  <StyledWrapper  ref={refWrapper}
+    return  <StyledWrapper  ref={ref}
                             aria-describedby={id}
                             className={className} 
                             tabIndex={0} 
@@ -341,38 +58,39 @@ export default function TooltipWrapper({lockVisible, className, pos, text, arrow
                             onMouseOver={() => setIsVisible(true)} 
                             >
                 {children}
-                <StyledTooltipContainer     ref={refTooltip} 
-                                            arrowPos={arrowDir} 
-                                            availableWidth={availableWidth()}
-                                            dimensions={tooltipSize}  
-                                            perpPos={pos} 
-                                            tooltipIsVisible={lockVisible || isVisible} 
-                                            >
-                    <Tooltip id={id} text={text} arrowPos={arrowPos} />
-                </StyledTooltipContainer>
+            {lockVisible || isVisible ? 
+                <TooltipPositioned  arrowPos={arrowPos} 
+                                    id={id}
+                                    pos={pos} 
+                                    text={text} 
+                                    wrapperPos={wrapperPos}
+                />
+                : null
+            }
             </StyledWrapper>
 }
 
-// type TooltipWrapperProps = {
-//     arrowPos? : TOOLTIP_ARROW_POSITION,
-//     availableWidth : number,
-//     perpPos? : TOOLTIP_POSITION,  
-//     tooltipIsVisible : boolean
-//     dimensions: { width : number, height : number },
-// }
+export type PositionsObj = {
+    left : number,
+    right : number,
+    top : number,
+    bottom : number,
+}
+ function useXPosition(ref : React.MutableRefObject<HTMLDivElement | null>) : PositionsObj{
+    const [positions, setPositions] = React.useState(getPositions);
 
-function useDimensions(targetRef : React.MutableRefObject<HTMLDivElement | null>) {
-    function getDimensions(){
+    function getPositions(){
+        const tarRect = ref.current ? ref.current.getBoundingClientRect() : null;
         return {
-            width: targetRef.current ? targetRef.current.offsetWidth : 0,
-            height: targetRef.current ? targetRef.current.offsetHeight : 0
-        };
+                left: tarRect ? tarRect.left : 0,
+                right: tarRect ? tarRect.right : 0,
+                top: tarRect ? tarRect.top : 0,
+                bottom: tarRect ? tarRect.bottom : 0,
+            };
     };
 
-    const [dimensions, setDimensions] = React.useState(getDimensions);
-
     function handleResize(){
-        setDimensions(getDimensions());
+        setPositions(getPositions());
     };
 
     React.useEffect(() => {
@@ -384,7 +102,6 @@ function useDimensions(targetRef : React.MutableRefObject<HTMLDivElement | null>
         handleResize();
     }, []);
 
-    return dimensions;
-  }
-
+    return positions;
+}
 

--- a/styles/reset.css
+++ b/styles/reset.css
@@ -20,9 +20,9 @@ max-width: 100%;
 input, button, textarea, select {
 font: inherit;
 }
-p, h1, h2, h3, h4, h5, h6 {
+/* p, h1, h2, h3, h4, h5, h6 {
 overflow-wrap: break-word;
-}
+} */
 ol, ul {
 	list-style: none;
 }

--- a/utils/tooltipPosUpdateToFit.tsx
+++ b/utils/tooltipPosUpdateToFit.tsx
@@ -1,195 +1,487 @@
 /*
     Helper function for Tooltip auto-positioning.
-
-    To handle width-responsiveness, Tooltips do this:
-        1) Tooltip is displayed with the settings the user specified.
-        2) Doesn't fit width-wise? Tooltip is displayed, but the settings are 
-           altered to make better use of screen space.
-        3) Still doesn't fit? Fullscreen mode.
-
-    This file contains a function to cover #2.
     
-    It takes in the current settings and some information about screen space and 
-    positioning, then works out if that will fit. If not, it returns settings
-    altered so that it /will/ fit.
-
-    If it has a choice, it will also pick the fitting settings that come closer
-    to the user's original sections.
-
-    Note: doesn't currently worry about fitting ot the height, since the user can 
-    just scroll.
+    Checks if the user's selection of mode and pointTo will fit on screen.
+    If not, it works out which alternative would fit and returns that.
+    If it has a choice, it will pick the alternative that comes closest to the 
+    user's original selection.
 */
 
-import { TOOLTIP_ARROW_POSITION as ARROW_POS } from '../components/Tooltip';
-import {    addSettingsToArrowPos, 
-            getXOffsetPx, 
-            TOOLTIP_POS, 
+import {    getSettingsForMode, 
+            tooltipFitsX, 
+            tooltipFitsY,
+            atSideOfTarget,
+            TOOLTIP_MODE as MODE,
+            POINTS_TO,
+            SIDE,
+            ARROW_FROM,
             T_DOMElementSettings,
-            T_MaxSpaceToEachSide, 
             T_TooltipOptions,
+            T_ModeWithSettings,
                 } from '../components/TooltipPositioned';
 
 
-function tooltipFits({settings, perpPos, wrapperPos, preferredWidth} : TooltipOptionsAndDOMElementSettings) : boolean{
-    let predictedPosition = getPreferredXPosition({settings, perpPos, wrapperPos, preferredWidth});
-    return predictedPosition.left >= 0 && predictedPosition.right <= window.innerWidth;
-}
-
-// Work out where the tooltip /would/ appear along the X-axis if we applied the given tooltip options
-type TooltipOptionsAndDOMElementSettings = T_TooltipOptions & T_DOMElementSettings;
-function getPreferredXPosition({settings, perpPos, wrapperPos, preferredWidth} : TooltipOptionsAndDOMElementSettings){
-    let offset = getXOffsetPx({settings, perpPos});
-    let prefPos = settings.atSideOfTarget ? 
-                    0 
-                    : getPreferredPosStaticSide({perpPos, settings, offset, wrapperPos});
-    
-    let left = 0;
-    let right = 0;
-
-    if(settings.fromLeft){
-        left = settings.atSideOfTarget ? wrapperPos.right + offset : prefPos;
-        right = left + preferredWidth;
-    }
-    else{
-        right = settings.atSideOfTarget ? wrapperPos.left - offset : prefPos;
-        left = right - preferredWidth;
-    }
-
-    return {
-        left,
-        right,
-    }
-}
-
-
-type T_PropsGetPreferredPosStaticSide = T_TooltipOptions & Pick<T_DOMElementSettings, "wrapperPos"> & {
-    offset: number,
-}
-function getPreferredPosStaticSide({settings, wrapperPos, offset, perpPos} : T_PropsGetPreferredPosStaticSide) : number{
-    let wrapperWidth = wrapperPos.right - wrapperPos.left;
-    let wrapperMid = wrapperPos.left + wrapperWidth / 2;
-
-    let directionalOffset = settings.fromLeft ? offset : -offset;
-
-    switch(perpPos){
-        case TOOLTIP_POS.start:
-            return wrapperPos.left - directionalOffset;
-
-        case TOOLTIP_POS.end:
-            return wrapperPos.right - directionalOffset;
-
-        case TOOLTIP_POS.center:
-            return wrapperMid - offset;
-            
-        default:
-            return 0;
-    }
-}
-
-
-// Alter the tooltip options so the tooltip will fit on the screen
-type PropsGetResponsiveOptions = TooltipOptionsAndDOMElementSettings & T_MaxSpaceToEachSide;
-function getResponsiveOptions({settings, perpPos, maxSpaceGoingLeft, maxSpaceGoingRight, preferredWidth, wrapperPos} : PropsGetResponsiveOptions) : T_TooltipOptions{
-    const useBottomX =  settings.fallbackTop === false 
-                        || ( settings.fallbackTop === undefined 
-                             && perpPos !== TOOLTIP_POS.end
-                            );
-    
-
-    // When swapping from a side-y tooltip, it would make sense to prefer for the arrow to be pointing to
-    // the same side as before (albeit now from above or below, instead of the side).
-    // If there is enough space, make that happen.
-    if(settings.atSideOfTarget){
-        let prefSide = updateOptionsTryPreferredSide({settings, useBottomX, wrapperPos, preferredWidth});
-        if(prefSide !== null){
-            return prefSide;
-        }
-    }
-
-    let result = updateOptionsUseMaxSpace({maxSpaceGoingLeft, maxSpaceGoingRight, useBottomX});
-    return result;
-}
-
-type T_VerticalFallbackFlag = {
-    useBottomX : boolean,
-}
-
-
-type T_PropsUpdateOptionsTryPreferredSide = T_DOMElementSettings & T_VerticalFallbackFlag & Pick<T_TooltipOptions, "settings">;
-function updateOptionsTryPreferredSide({settings, useBottomX, wrapperPos, preferredWidth} : T_PropsUpdateOptionsTryPreferredSide) : T_TooltipOptions | null{
-    if(!settings.atSideOfTarget){
-        return null;
-    }
-
-    let newArrowDir : ARROW_POS;
-    let newPerpPos : TOOLTIP_POS;
-
-    if(settings.fallbackLeft){
-        newArrowDir = useBottomX ? ARROW_POS.topLeft : ARROW_POS.bottomLeft;
-        newPerpPos = TOOLTIP_POS.start;
-    }
-    else{
-        newArrowDir = useBottomX ? ARROW_POS.topRight : ARROW_POS.bottomRight;
-        newPerpPos = TOOLTIP_POS.end;
-    }
-
-    let newSettings = addSettingsToArrowPos(newArrowDir);
-    let willFit = tooltipFits({settings: newSettings, perpPos: newPerpPos, wrapperPos, preferredWidth});
-
-    if(!willFit){
-        return null;
-    }
-    return {
-        perpPos: newPerpPos,
-        settings: newSettings,
-    }
-    
-}
-
-type T_PropsUpdateOptionsUseMaxSpace = T_MaxSpaceToEachSide & T_VerticalFallbackFlag;
-function updateOptionsUseMaxSpace({maxSpaceGoingLeft, maxSpaceGoingRight, useBottomX} : T_PropsUpdateOptionsUseMaxSpace) : T_TooltipOptions {
-    let newArrowDir : ARROW_POS;
-    let newPerpPos : TOOLTIP_POS;
-
-    if(maxSpaceGoingLeft > maxSpaceGoingRight){
-        newPerpPos = TOOLTIP_POS.end;
-        newArrowDir = useBottomX ? ARROW_POS.bottomRight : ARROW_POS.topRight;
-    }
-    else{
-        newPerpPos = TOOLTIP_POS.start;
-        newArrowDir = useBottomX ? ARROW_POS.bottomLeft : ARROW_POS.topLeft;
-    }
-
-    let newSettings = addSettingsToArrowPos(newArrowDir);
-    return {
-        perpPos: newPerpPos,
-        settings: newSettings,
-    }
-}
-
-
-type T_PropsUpdateTooltipOptionsToFit = T_TooltipOptions & T_DOMElementSettings & T_MaxSpaceToEachSide & {
-    fullscreenMode : boolean,
+type T_PriorityFlag = {
+    prioritiseMode : boolean
 };
-export default function updateTooltipOptionsToFit({settings, perpPos, fullscreenMode, wrapperPos, preferredWidth, maxSpaceGoingLeft, maxSpaceGoingRight} : T_PropsUpdateTooltipOptionsToFit) : T_TooltipOptions{
+
+type T_PropsUpdateTooltipOptionsToFit = 
+    T_TooltipOptions 
+    & T_DOMElementSettings
+    & T_PriorityFlag;
+
+type T_FittingOptionsOrNull = T_TooltipOptions | null;
+
+export default function getTooltipOptionsThatFit({modeSettings, pointTo, wrapperPos, preferredWidth, preferredHeight, prioritiseMode} 
+    : T_PropsUpdateTooltipOptionsToFit) 
+    : T_TooltipOptions {
     
-    // Fullscreen mode is handling the question of "what if it *CAN'T* fit?".
-    // If fullscreen mode is inactive, we can assume the tooltip could fit (maybe with a little help).
-    if(!fullscreenMode){
-        let wrapperPosIsEmpty = wrapperPos.left === 0 && wrapperPos.right === 0;
-        let willFit = tooltipFits({settings, perpPos, wrapperPos, preferredWidth});
-        if(!wrapperPosIsEmpty && !willFit){
-            let responsive = getResponsiveOptions({wrapperPos, settings, perpPos, preferredWidth, maxSpaceGoingLeft, maxSpaceGoingRight});
-            settings = responsive.settings;
-            perpPos = responsive.perpPos;
+    let wrapperPosIsEmpty : boolean = wrapperPos.left === 0 && wrapperPos.right === 0;
+    let willFitX : boolean = tooltipFitsX({modeSettings, pointTo, wrapperPos, preferredWidth});
+    let willFitY : boolean = tooltipFitsY({modeSettings, pointTo, wrapperPos, preferredHeight});
+
+    if(!wrapperPosIsEmpty && (!willFitX || !willFitY)){
+        let optionsThatFit : T_FittingOptionsOrNull = getClosestOptionsThatFit({ modeSettings, pointTo, wrapperPos, preferredWidth, preferredHeight, prioritiseMode });
+        if(optionsThatFit !== null){
+            return optionsThatFit;
         }
     }
-    
+
     return {
-        settings,
-        perpPos
+        modeSettings,
+        pointTo
     }
 }
 
+
+type T_SidesFit = {
+    [SIDE.above] : boolean | undefined,
+    [SIDE.below]: boolean | undefined,
+    [SIDE.left]: boolean | undefined,
+    [SIDE.right]: boolean | undefined,
+}
+
+function getClosestOptionsThatFit({modeSettings, pointTo, wrapperPos, preferredWidth, preferredHeight, prioritiseMode} 
+    : T_TooltipOptions & T_DOMElementSettings & T_PriorityFlag) 
+    : T_FittingOptionsOrNull {
+
+    let optionsOrderedByCloseness : T_TooltipOptions[] = getOptionsInOrder({modeSettings, pointTo, prioritiseMode});
+    let sharedProps : T_DOMElementSettings = { wrapperPos, preferredWidth, preferredHeight};
+
+    // Map to avoid repeating checks. We've already checked the user's selection, so add that to the map.
+    let optionsMemo : Map<string, boolean> = new Map<string, boolean>();
+    let key : string = getKeyStr({modeSettings, pointTo});
+    optionsMemo.set(key, true);
+
+    let sideFits : T_SidesFit = {
+        [SIDE.above]: undefined,
+        [SIDE.below]: undefined,
+        [SIDE.left]: undefined,
+        [SIDE.right]: undefined,
+    };
+
+    for(let idx = 0; idx < optionsOrderedByCloseness.length; idx++){
+        let loopSettings : T_ModeWithSettings = optionsOrderedByCloseness[idx].modeSettings;
+        let loopOptions : T_TooltipOptions = {  modeSettings: loopSettings, 
+                                                pointTo: optionsOrderedByCloseness[idx].pointTo};
+
+        let memoStr : string = getKeyStr({...loopOptions});
+        if(!optionsMemo.has(memoStr)){
+            optionsMemo.set(memoStr, true);
+
+            let sideFitsOutwards : boolean | undefined = sideFits[loopSettings.side];
+            if(sideFitsOutwards === undefined){
+                sideFitsOutwards = tooltipFitsOutwards({...sharedProps, ...loopOptions});
+                sideFits[loopSettings.side] = sideFitsOutwards;
+            }
+            if(sideFitsOutwards){
+                let loopOptionsFit = tooltipFitsPerpendicularly({...sharedProps, ...loopOptions});
+                if(loopOptionsFit){
+                    return {...loopOptions};
+                }
+            }
+        }
+    }
+    return null;
+}
+
+
+function getKeyStr({modeSettings, pointTo} 
+    : T_TooltipOptions)
+    : string {
+    
+    return `${modeSettings.mode}@${pointTo}`;
+}
+
+
+function tooltipFitsOutwards({modeSettings, pointTo, wrapperPos, preferredWidth, preferredHeight} 
+    : T_TooltipOptions & T_DOMElementSettings)
+    : boolean {
+
+    return atSideOfTarget(modeSettings) ?
+                tooltipFitsX({modeSettings, pointTo, wrapperPos, preferredWidth})
+                : tooltipFitsY({modeSettings, pointTo, wrapperPos, preferredHeight});
+}
+
+
+function tooltipFitsPerpendicularly({modeSettings, pointTo, wrapperPos, preferredWidth, preferredHeight}
+    : T_TooltipOptions & T_DOMElementSettings)
+    : boolean {
+    
+    return atSideOfTarget(modeSettings) ?
+                tooltipFitsY({modeSettings, pointTo, wrapperPos, preferredHeight})
+                : tooltipFitsX({modeSettings, pointTo, wrapperPos, preferredWidth});
+}
+
+
+// || Everything below here is connected to putting the options in order
+function getOptionsInOrder({modeSettings, pointTo, prioritiseMode} 
+    : T_TooltipOptions & T_PriorityFlag)
+    : T_TooltipOptions[] {
+    
+    // Get relative definitions
+    let relDef : T_RelativeModeSettings = getRelativeSettings({modeSettings, pointTo});
+    let {opposite, nearPerp, farPerp, perpPointTo} : T_RelativeModeSettings = relDef;
+
+    if(atSideOfTarget(modeSettings)){
+        return getOptionsInOrderLeftRight({modeSettings, pointTo, opposite, nearPerp, farPerp, perpPointTo});
+    }
+    else{
+        return getOptionsInOrderAboveBelow({modeSettings, pointTo, opposite, nearPerp, farPerp, perpPointTo, prioritiseMode});
+    }
+}
+
+
+function getOptionsInOrderLeftRight({modeSettings, pointTo, opposite, nearPerp, farPerp, perpPointTo}
+    : T_TooltipOptions & T_RelativeModeSettings)
+    : T_TooltipOptions[] {
+
+    // 1) Get other pointTo options on the same side. left|right don't have any settingsToWeave, so ignore that.
+    let orderedArr : T_TooltipOptions[] = getOptionCombos({modeSettings, pointTo, settingsToWeave: null, excludeFirst: true});
+
+    // 2) The two "xPerp @ perpPointTo" combos have so much in common with a side-y tooltip -- they're almost "pre-start"
+    // and "post-end" -- that we're going to pretend they're on the same side as the user's selection and prioritise 
+    // them accordingly. We will use excludeFirst later to avoid duplication.
+    orderedArr.push({modeSettings: nearPerp, pointTo: perpPointTo});
+    orderedArr.push({modeSettings: farPerp, pointTo: perpPointTo});
+
+    // 3) and 4) varies depending on pointTo. Prepare some props objects to keep things DRY when setting up different orders
+    let propsOpp =  {modeSettings: opposite,    pointTo,                settingsToWeave: null };
+    let propsNear = {modeSettings: nearPerp,    pointTo: perpPointTo,   settingsToWeave: getSettingsSameSide(nearPerp),  excludeFirst: true};
+
+    if(pointTo === POINTS_TO.center){
+        /*  o  The tooltip content is also centered around the arrow, so both perp sides are equally "near" and "far"
+               and it makes no sense to prioritise one over the other. They should be grouped together, similar prio.
+            o  The opposite side preserves the distinctive "poking out the side" look, so let's prioritise that over
+               shuffling the tooltip across above|below.
+        */
+        orderedArr = orderedArr.concat(getOptionCombos(propsOpp));
+        orderedArr = orderedArr.concat(getOptionCombos(propsNear));
+    }
+    else{
+        // It's pointing near a corner, so it makes sense to "pop around the corner" before jumping to the opposite side
+        orderedArr = orderedArr.concat(getOptionCombos(propsNear));
+        orderedArr = orderedArr.concat(getOptionCombos(propsOpp)); 
+    }
+
+    // 5) All that remains is the remainder of "far"
+    orderedArr = orderedArr.concat( getOptionCombos({   modeSettings: farPerp, 
+                                                        pointTo: perpPointTo, 
+                                                        settingsToWeave: getSettingsSameSide(farPerp), 
+                                                        excludeFirst: true 
+                                                }));
+    return orderedArr;
+}
+
+
+function getOptionsInOrderAboveBelow({modeSettings, pointTo, prioritiseMode, opposite, nearPerp, farPerp, perpPointTo} 
+    : T_TooltipOptions & T_PriorityFlag & T_RelativeModeSettings)
+    : T_TooltipOptions[] {
+
+    let orderedArr : T_TooltipOptions[] = [];
+
+    // Begin with options on the same side as the user's selection. Use excludeFirst to avoid duplicating the 
+    // user's exact selection (if that would fit on the screen, we wouldn't be here).
+
+    // All above|below modes have a "sideSharer" mode (i.e. same side, opposite arrowFrom), so there's a question
+    // of prioritisation: do we try both modes before changing the pointTo or do we try all pointTos before changing
+    // the mode?
+
+    // To prioritise preservation of the mode, run the function twice: no weaving
+    let sideSharer : T_ModeWithSettings | null = getSettingsSameSide(modeSettings);
+    if(prioritiseMode){
+        orderedArr = orderedArr.concat(getOptionCombos({modeSettings, pointTo, settingsToWeave: null, excludeFirst: true}));
+        if(sideSharer){
+            orderedArr = orderedArr.concat(getOptionCombos({modeSettings: sideSharer, pointTo, settingsToWeave: null}));
+        }
+    }
+    // To prioritise preservation of the pointTo, weave away.
+    else{
+        orderedArr = orderedArr.concat(getOptionCombos({modeSettings, pointTo, settingsToWeave: sideSharer, excludeFirst: true}));
+    }
+
+    // above|below are always closer to one corner or the other -- either they're pointing to it with the arrow
+    // or the content is looming over it (or, at least, sticking out towards it) -- so pop around the nearest corner.
+    orderedArr = orderedArr.concat(getOptionCombos({ modeSettings: nearPerp, pointTo: perpPointTo, settingsToWeave: null }));
+
+    // The opposite side comes closer to the look of the user's selected options.
+    orderedArr = orderedArr.concat(getOptionCombos({modeSettings: opposite, pointTo, settingsToWeave: getSettingsSameSide(opposite) }));
+
+    // Far perpendicular side is all that's left.
+    orderedArr = orderedArr.concat(getOptionCombos({ modeSettings: farPerp, pointTo: perpPointTo, settingsToWeave: null }));
+
+    return orderedArr;
+}
+
+
+type T_GetAllPointToProps = {
+    settingsToWeave : T_ModeWithSettings | null,
+    excludeFirst? : boolean,
+};
+function getOptionCombos({modeSettings, pointTo, settingsToWeave, excludeFirst = false}
+    : T_TooltipOptions & T_GetAllPointToProps)
+    : T_TooltipOptions[] {
+
+    let optionsArr : T_TooltipOptions[] = [];
+
+    const pointToArr : POINTS_TO[] = Object.values(POINTS_TO);
+    let idxOfSelected : number = pointToArr.findIndex((ele) => ele === pointTo);
+    let direction : number = pointTo === POINTS_TO.end ? -1 : 1;
+
+    for(let counter : number = 0; counter < pointToArr.length; counter++){
+        let loopIdx : number = idxOfSelected + counter * direction % pointToArr.length;
+        let loopPointTo : POINTS_TO = pointToArr[loopIdx];
+        
+        if(!excludeFirst || counter > 0){
+            optionsArr.push({modeSettings, pointTo: loopPointTo});
+        }
+        
+        if(settingsToWeave){
+            optionsArr.push({modeSettings: settingsToWeave, pointTo: loopPointTo});
+        }
+    }
+    return optionsArr;
+}
+
+
+// || Relative modeSettings
+type T_RelativeModeSettings = {
+    opposite: T_ModeWithSettings,
+    nearPerp: T_ModeWithSettings,
+    farPerp: T_ModeWithSettings,
+    perpPointTo: POINTS_TO,
+};
+function getRelativeSettings({modeSettings, pointTo} 
+    : T_TooltipOptions)
+    : T_RelativeModeSettings{
+
+    let { near, far } : T_PerpendicularSideModes = getModesPerpendicularSides({modeSettings, pointTo});
+
+    return {
+        opposite: getSettingsOpposite(modeSettings),
+        nearPerp: getSettingsForMode(near),
+        farPerp: getSettingsForMode(far),
+        perpPointTo: getClosestPerpPointTo(modeSettings),
+    }
+}
+
+
+function getClosestPerpPointTo(modeSettings 
+    : T_ModeWithSettings)
+    : POINTS_TO {
+
+    return modeSettings.side === SIDE.above || modeSettings.side === SIDE.left ?
+                POINTS_TO.start
+                : POINTS_TO.end;
+}
+
+
+type T_PerpendicularSideModes = {
+    near : MODE,
+    far : MODE,
+};
+function getModesPerpendicularSides({modeSettings, pointTo} 
+    : T_TooltipOptions)
+    : T_PerpendicularSideModes{
+
+    let near : MODE;
+    let {startMode, endMode} : T_StartEndModes = getModesPerpStartEnd(modeSettings);
+
+    // Center and not-side-y means the arrow is centered but the content is skewed to one side. 
+    // Return the perp side closest to the content.
+    if(pointTo === POINTS_TO.center && !atSideOfTarget(modeSettings)){
+        let contentGrowsTowards : POINTS_TO | null = getContentGrowthDirection(modeSettings);
+        near = contentGrowsTowards === POINTS_TO.start ?
+            startMode
+            : endMode;
+    }
+    // Not-center means we return the side closest to where the arrow is pointing to. 
+    // Center & side-y means neither perp. side is closer to anything, but we need to pick ONE of 
+    // them to try first, so let's arbitrarily pick the startMode.
+    else{
+        near = pointTo === POINTS_TO.end ? endMode : startMode;
+    }
+
+    return {
+        near,
+        far: near === startMode ? endMode : startMode,
+    }
+}
+
+
+function getContentGrowthDirection(modeSettings 
+    : T_ModeWithSettings)
+    : POINTS_TO | null {  
+
+    // Side-y tooltips grow evenly in both directions, so return null
+    if(atSideOfTarget(modeSettings)){
+        return null;
+    }
+
+    // Otherwise, the design is such that the content grows away from the arrow
+    return modeSettings.arrowFrom === ARROW_FROM.left ?
+                POINTS_TO.end
+                : POINTS_TO.start;
+}
+
+
+type T_StartEndModes = {
+    startMode : MODE,
+    endMode : MODE,
+};
+function getModesPerpStartEnd(modeSettings 
+    : T_ModeWithSettings)
+    : T_StartEndModes {
+
+    let startMode : MODE;
+    let endMode : MODE;
+    
+    // Straightforward when selection was above|below, because left|right each only have one mode
+    if(modeSettings.side === SIDE.above || modeSettings.side === SIDE.below){
+        startMode = MODE.leftWithArrowMid;
+        endMode = MODE.rightWithArrowMid;
+    }
+/* 
+    In the case of a left|right selection, there's an extra decision to make. above|below each have 
+    two modes, so we need to pick which arrowFrom position we want as well.
+
+    The reasoning behind the choice is best illustrated with this stab at ASCII "art".
+    
+    rightWithArrowMid @ start:
+                                                    
+                                _______________________
+            ------------------ <___tooltip blah blah___|
+            | TARGET ELEMENT | 
+            ------------------
+
+
+    Looks a lot closer to aboveWithArrowLeft @ end:
+
+                            _______________________
+                           |_ _tooltip blah blah___|
+                             V                      
+            ------------------
+            | TARGET ELEMENT |
+            ------------------
+
+
+    Than aboveWithArrowRight @ end:
+        _______________________
+       |___tooltip blah blah_ _|
+                             V
+            ------------------
+            | TARGET ELEMENT |
+            ------------------
+
+    So we prioritise the opposite arrowFrom to the original side, so the tooltip "sticks out".
+
+    Of course, aboveWithArrowLeft @ end is /so/ close to rightWithArrowMid @ start that if one
+    doesn't fit then it's pretty likely the other won't either, but meh: that's another 
+    function's problem.
+*/
+    else{
+        startMode = modeSettings.side === SIDE.left ?
+                        MODE.aboveWithArrowRight 
+                        : MODE.aboveWithArrowLeft;
+        endMode = modeSettings.side === SIDE.left ?
+                        MODE.belowWithArrowRight
+                        : MODE.belowWithArrowLeft;
+    }
+
+    return {
+        startMode,
+        endMode,
+    }
+}
+
+
+function getSettingsSameSide(modeSettings 
+    : T_ModeWithSettings) 
+    : T_ModeWithSettings | null {
+
+    let modeArr : MODE[] = Object.values(MODE);
+    for(let modeIdx = 0; modeIdx < modeArr.length; modeIdx++){
+        let loopSettings : T_ModeWithSettings = getSettingsForMode(modeArr[modeIdx]);
+        if( loopSettings.side === modeSettings.side
+            && loopSettings.arrowFrom !== modeSettings.arrowFrom)
+        {
+            return loopSettings;
+        }
+    }
+    return null;
+}
+
+
+function getSettingsOpposite(modeSettings
+    : T_ModeWithSettings)
+    : T_ModeWithSettings {
+
+    // getSideOpposite shouldn't return null, since ALL sides should be covered.
+    // If it does then eh, return the original modeSettings. The memo will prevent
+    // repeating the same tests twice, so it won't cause much harm.
+    let oppSide = getSideOpposite(modeSettings.side);
+    if(!oppSide){
+        return modeSettings;
+    }
+
+    let modeArr = Object.values(MODE);
+    for(let modeIdx = 0; modeIdx < modeArr.length; modeIdx++){
+        let loopSettings = getSettingsForMode(modeArr[modeIdx]);
+        if( loopSettings.side === oppSide
+            && loopSettings.arrowFrom === modeSettings.arrowFrom)
+        {
+            return loopSettings;
+        }
+    }
+
+    // The loop above should always return some loopSettings. If it doesn't,
+    // something weird has happened so, again, let's fallback to returning 
+    // the original modeSettings.
+    return modeSettings;
+}
+
+
+function getSideOpposite(side 
+    : SIDE )
+    : SIDE | null {
+
+    const opposites = [
+        [SIDE.above, SIDE.below],
+        [SIDE.left, SIDE.right],
+    ];
+
+    for(let idx = 0; idx < opposites.length; idx++){
+        let side1 = opposites[idx][0];
+        let side2 = opposites[idx][1];
+
+        if(side === side1){
+            return side2;
+        }
+        if(side === side2){
+            return side1;
+        }
+    }
+    return null;
+}
 
 

--- a/utils/tooltipPosUpdateToFit.tsx
+++ b/utils/tooltipPosUpdateToFit.tsx
@@ -1,0 +1,195 @@
+/*
+    Helper function for Tooltip auto-positioning.
+
+    To handle width-responsiveness, Tooltips do this:
+        1) Tooltip is displayed with the settings the user specified.
+        2) Doesn't fit width-wise? Tooltip is displayed, but the settings are 
+           altered to make better use of screen space.
+        3) Still doesn't fit? Fullscreen mode.
+
+    This file contains a function to cover #2.
+    
+    It takes in the current settings and some information about screen space and 
+    positioning, then works out if that will fit. If not, it returns settings
+    altered so that it /will/ fit.
+
+    If it has a choice, it will also pick the fitting settings that come closer
+    to the user's original sections.
+
+    Note: doesn't currently worry about fitting ot the height, since the user can 
+    just scroll.
+*/
+
+import { TOOLTIP_ARROW_POSITION as ARROW_POS } from '../components/Tooltip';
+import {    addSettingsToArrowPos, 
+            getXOffsetPx, 
+            TOOLTIP_POS, 
+            T_DOMElementSettings,
+            T_MaxSpaceToEachSide, 
+            T_TooltipOptions,
+                } from '../components/TooltipPositioned';
+
+
+function tooltipFits({settings, perpPos, wrapperPos, preferredWidth} : TooltipOptionsAndDOMElementSettings) : boolean{
+    let predictedPosition = getPreferredXPosition({settings, perpPos, wrapperPos, preferredWidth});
+    return predictedPosition.left >= 0 && predictedPosition.right <= window.innerWidth;
+}
+
+// Work out where the tooltip /would/ appear along the X-axis if we applied the given tooltip options
+type TooltipOptionsAndDOMElementSettings = T_TooltipOptions & T_DOMElementSettings;
+function getPreferredXPosition({settings, perpPos, wrapperPos, preferredWidth} : TooltipOptionsAndDOMElementSettings){
+    let offset = getXOffsetPx({settings, perpPos});
+    let prefPos = settings.atSideOfTarget ? 
+                    0 
+                    : getPreferredPosStaticSide({perpPos, settings, offset, wrapperPos});
+    
+    let left = 0;
+    let right = 0;
+
+    if(settings.fromLeft){
+        left = settings.atSideOfTarget ? wrapperPos.right + offset : prefPos;
+        right = left + preferredWidth;
+    }
+    else{
+        right = settings.atSideOfTarget ? wrapperPos.left - offset : prefPos;
+        left = right - preferredWidth;
+    }
+
+    return {
+        left,
+        right,
+    }
+}
+
+
+type T_PropsGetPreferredPosStaticSide = T_TooltipOptions & Pick<T_DOMElementSettings, "wrapperPos"> & {
+    offset: number,
+}
+function getPreferredPosStaticSide({settings, wrapperPos, offset, perpPos} : T_PropsGetPreferredPosStaticSide) : number{
+    let wrapperWidth = wrapperPos.right - wrapperPos.left;
+    let wrapperMid = wrapperPos.left + wrapperWidth / 2;
+
+    let directionalOffset = settings.fromLeft ? offset : -offset;
+
+    switch(perpPos){
+        case TOOLTIP_POS.start:
+            return wrapperPos.left - directionalOffset;
+
+        case TOOLTIP_POS.end:
+            return wrapperPos.right - directionalOffset;
+
+        case TOOLTIP_POS.center:
+            return wrapperMid - offset;
+            
+        default:
+            return 0;
+    }
+}
+
+
+// Alter the tooltip options so the tooltip will fit on the screen
+type PropsGetResponsiveOptions = TooltipOptionsAndDOMElementSettings & T_MaxSpaceToEachSide;
+function getResponsiveOptions({settings, perpPos, maxSpaceGoingLeft, maxSpaceGoingRight, preferredWidth, wrapperPos} : PropsGetResponsiveOptions) : T_TooltipOptions{
+    const useBottomX =  settings.fallbackTop === false 
+                        || ( settings.fallbackTop === undefined 
+                             && perpPos !== TOOLTIP_POS.end
+                            );
+    
+
+    // When swapping from a side-y tooltip, it would make sense to prefer for the arrow to be pointing to
+    // the same side as before (albeit now from above or below, instead of the side).
+    // If there is enough space, make that happen.
+    if(settings.atSideOfTarget){
+        let prefSide = updateOptionsTryPreferredSide({settings, useBottomX, wrapperPos, preferredWidth});
+        if(prefSide !== null){
+            return prefSide;
+        }
+    }
+
+    let result = updateOptionsUseMaxSpace({maxSpaceGoingLeft, maxSpaceGoingRight, useBottomX});
+    return result;
+}
+
+type T_VerticalFallbackFlag = {
+    useBottomX : boolean,
+}
+
+
+type T_PropsUpdateOptionsTryPreferredSide = T_DOMElementSettings & T_VerticalFallbackFlag & Pick<T_TooltipOptions, "settings">;
+function updateOptionsTryPreferredSide({settings, useBottomX, wrapperPos, preferredWidth} : T_PropsUpdateOptionsTryPreferredSide) : T_TooltipOptions | null{
+    if(!settings.atSideOfTarget){
+        return null;
+    }
+
+    let newArrowDir : ARROW_POS;
+    let newPerpPos : TOOLTIP_POS;
+
+    if(settings.fallbackLeft){
+        newArrowDir = useBottomX ? ARROW_POS.topLeft : ARROW_POS.bottomLeft;
+        newPerpPos = TOOLTIP_POS.start;
+    }
+    else{
+        newArrowDir = useBottomX ? ARROW_POS.topRight : ARROW_POS.bottomRight;
+        newPerpPos = TOOLTIP_POS.end;
+    }
+
+    let newSettings = addSettingsToArrowPos(newArrowDir);
+    let willFit = tooltipFits({settings: newSettings, perpPos: newPerpPos, wrapperPos, preferredWidth});
+
+    if(!willFit){
+        return null;
+    }
+    return {
+        perpPos: newPerpPos,
+        settings: newSettings,
+    }
+    
+}
+
+type T_PropsUpdateOptionsUseMaxSpace = T_MaxSpaceToEachSide & T_VerticalFallbackFlag;
+function updateOptionsUseMaxSpace({maxSpaceGoingLeft, maxSpaceGoingRight, useBottomX} : T_PropsUpdateOptionsUseMaxSpace) : T_TooltipOptions {
+    let newArrowDir : ARROW_POS;
+    let newPerpPos : TOOLTIP_POS;
+
+    if(maxSpaceGoingLeft > maxSpaceGoingRight){
+        newPerpPos = TOOLTIP_POS.end;
+        newArrowDir = useBottomX ? ARROW_POS.bottomRight : ARROW_POS.topRight;
+    }
+    else{
+        newPerpPos = TOOLTIP_POS.start;
+        newArrowDir = useBottomX ? ARROW_POS.bottomLeft : ARROW_POS.topLeft;
+    }
+
+    let newSettings = addSettingsToArrowPos(newArrowDir);
+    return {
+        perpPos: newPerpPos,
+        settings: newSettings,
+    }
+}
+
+
+type T_PropsUpdateTooltipOptionsToFit = T_TooltipOptions & T_DOMElementSettings & T_MaxSpaceToEachSide & {
+    fullscreenMode : boolean,
+};
+export default function updateTooltipOptionsToFit({settings, perpPos, fullscreenMode, wrapperPos, preferredWidth, maxSpaceGoingLeft, maxSpaceGoingRight} : T_PropsUpdateTooltipOptionsToFit) : T_TooltipOptions{
+    
+    // Fullscreen mode is handling the question of "what if it *CAN'T* fit?".
+    // If fullscreen mode is inactive, we can assume the tooltip could fit (maybe with a little help).
+    if(!fullscreenMode){
+        let wrapperPosIsEmpty = wrapperPos.left === 0 && wrapperPos.right === 0;
+        let willFit = tooltipFits({settings, perpPos, wrapperPos, preferredWidth});
+        if(!wrapperPosIsEmpty && !willFit){
+            let responsive = getResponsiveOptions({wrapperPos, settings, perpPos, preferredWidth, maxSpaceGoingLeft, maxSpaceGoingRight});
+            settings = responsive.settings;
+            perpPos = responsive.perpPos;
+        }
+    }
+    
+    return {
+        settings,
+        perpPos
+    }
+}
+
+
+

--- a/utils/utils.tsx
+++ b/utils/utils.tsx
@@ -28,16 +28,6 @@ export const visuallyHidden = css`
     width: 1px;
 `;
 
-export const visuallyUnhidden = css`
-    clip: auto;
-    clip-path: none;
-    height: auto;
-    overflow: visible;
-    position: absolute;
-    white-space: normal;
-    width: auto;
-`;
-
 type MoveWithMenuPropsType = {
     e: React.KeyboardEvent, 
     options : any[] | null | undefined, 
@@ -123,3 +113,5 @@ export function changeRadio(id : string, checked : boolean, options : RadioOptio
     });
     setOptions(newOptions);
 }
+
+


### PR DESCRIPTION
Added TooltipWrapper component for functionality of Tooltips.
> Displays on hover (mouse), focus(keyboard) and tap (touchscreen)
> Hides on hover off (mouse), blur and escape (keyboard) and another tap (touchscreen)

Added responsiveness. If the Tooltip won't fit on screen with the positioning specified by the user, it will either swap to the closest alternative position or, if none of the positions will fit, switches to "fullscreenMode" and appears as a bubble at the top of the screen.

Added TooltipWrapper stories using the newer CSF3 syntax.

