### PR TITLE
Refactor. More use of Paragraph and Heading

### DIFF
--- a/components/Badge.tsx
+++ b/components/Badge.tsx
@@ -3,6 +3,8 @@ import styled, { ThemeProvider } from 'styled-components';
 
 import { theme as themeObj } from '../styles/theme';
 
+import Paragraph from './Paragraph';
+
 export enum BadgeType{
     primary = "primary",
     secondary = "secondary",
@@ -69,8 +71,7 @@ const StyledBadge = styled.div.attrs(props => ({
     width: fit-content;
 `;
 
-const StyledBadgeText = styled.p`
-    ${ ({theme}) => theme.typography.p3Bold}
+const StyledBadgeText = styled(Paragraph)`
     color: ${props => props.theme.colour};
     overflow: hidden;
     text-overflow: ellipsis;
@@ -89,7 +90,7 @@ export default function Badge({text, type} : BadgeProps){
     const theme = getTheme(type);
     return <ThemeProvider theme = {theme}>
                 <StyledBadge>
-                    <StyledBadgeText>
+                    <StyledBadgeText size={3} bold={true}>
                         {text}
                     </StyledBadgeText>
                 </StyledBadge>

--- a/components/Island.tsx
+++ b/components/Island.tsx
@@ -8,6 +8,8 @@ import { Icon, ICON_ID, ICON_SIZES, getIconIdFromSubject } from './icons/';
 
 import Button, { ButtonStyle } from './Button';
 import Badge, { BadgeType } from './Badge';
+import Heading from './Heading';
+import Paragraph from './Paragraph';
 
 
 const StyledIsland = styled.div.attrs({
@@ -56,8 +58,7 @@ const StyledProgressBar = styled.div<Pick<I_IslandProps, "progress">>`
     }
 `;
 
-const StyledProgressText = styled.p`
-    ${ ({theme}) => theme.typography.p3 };
+const StyledProgressText = styled(Paragraph)`
     color: ${ ({theme}) => theme.color.textOnPrimary };
 `;
 
@@ -105,14 +106,12 @@ const StyledLayout = styled.div`
     }
 `;
 
-const StyledHead = styled.h6`
-    ${ ({theme}) => theme.typography.h6 }
+const StyledHead = styled(Heading)`
     color: ${ ({theme}) => theme.color.textOnPrimary };
     grid-area: heading;
 `;
 
-const StyledDescription = styled.p`
-    ${ ({theme}) => theme.typography.p2 }
+const StyledDescription = styled(Paragraph)`
     color: ${ ({theme}) => addOpacityToColor(theme.color.textOnPrimary, theme.opacity.subtleTextOnPrimary) };
     grid-area: desc;
     height: 100%;
@@ -205,8 +204,8 @@ export default function Island({progress, subject, text, heading, description, b
 
             <StyledLayout>
                 <Badge text={text} type={BadgeType.white} />
-                <StyledHead>{heading}</StyledHead>
-                <StyledDescription>{description}</StyledDescription>
+                <StyledHead level={6}>{heading}</StyledHead>
+                <StyledDescription size={2}>{description}</StyledDescription>
                 <StyledButtonContainer>
                     <Button style={ButtonStyle.secondaryWhite}
                             disabled={false}
@@ -231,7 +230,7 @@ export default function Island({progress, subject, text, heading, description, b
 
 function ProgressBar({progress} : Pick<I_IslandProps, "progress">){
     return  <StyledProgressBar progress={progress}>
-                <StyledProgressText>
+                <StyledProgressText size={3}>
                     Progress {progress}%
                 </StyledProgressText>
             </StyledProgressBar>

--- a/components/Notification.tsx
+++ b/components/Notification.tsx
@@ -8,6 +8,7 @@ import { Icon, ICON_ID, ICON_SIZES } from './icons/';
 
 import Button, { ButtonStyle } from './Button';
 import CircleContainer from './CircleAroundIcon';
+import Paragraph from './Paragraph';
 
 
 function getMobileBreakpoint() : string {
@@ -45,8 +46,7 @@ const StyledButtonsContainer = styled.div`
     }
 `;
 
-const StyledDescription = styled.p`
-    ${ ({theme}) => theme.typography.p2 }
+const StyledDescription = styled(Paragraph)`
     align-items: center;
     display: flex;
 `;
@@ -130,7 +130,7 @@ export default function Notification({type, heading, description, buttonActions}
                     }
                     {
                         (hasDescription || !hasHeading) && 
-                        <StyledDescription>
+                        <StyledDescription size={2}>
                             {description}
                         </StyledDescription>
                     }

--- a/components/PopUpPreset.tsx
+++ b/components/PopUpPreset.tsx
@@ -7,6 +7,8 @@ import { Icon, ICON_ID, ICON_SIZES } from './icons/';
 
 import Button, { ButtonStyle } from './Button';
 import CircleAroundIcon from './CircleAroundIcon';
+import Heading from './Heading';
+import Paragraph from './Paragraph';
 
 export const enum PopUpPresetMode{
     success = "success",
@@ -80,14 +82,9 @@ const StyledLayout = styled.div`
     }
 `;  
 
-const StyledHeading = styled.h4`
-    ${ ({theme}) => theme.typography.h4 }
+const StyledHeading = styled(Heading)`
     padding-top: .8rem;
     text-align: center;
-`;
-
-const StyledDescription = styled.p`
-    ${ ({theme}) => theme.typography.p2 }
 `;
 
 const StyledButtonContainer = styled.div`
@@ -108,12 +105,12 @@ export default function PopUpPreset({description, heading, mode: type, buttonPri
             <StyledCircleAroundIcon bg={theme.background} size={"6rem"}>
                 <Icon id={theme.iconId} size={ICON_SIZES.extraLarge} />
             </StyledCircleAroundIcon>
-            <StyledHeading>
+            <StyledHeading level={4}>
                 {heading}
             </StyledHeading>
-            <StyledDescription>
+            <Paragraph size={2}>
                 {description}
-            </StyledDescription>
+            </Paragraph>
             {(buttonPrimary !== undefined || buttonSecondary !== undefined) &&
                 <ButtonContainer buttonPrimary={buttonPrimary} buttonSecondary={buttonSecondary} />
             }

--- a/components/form/FileUploader.tsx
+++ b/components/form/FileUploader.tsx
@@ -2,11 +2,11 @@ import React, { useEffect } from 'react';
 import styled from 'styled-components';
 
 import { addOpacityToColor } from '../../utils/utils';
-import { theme as themeObj } from '../../styles/theme';
 
 import { Icon, ICON_ID, ICON_SIZES } from '../icons/';
 import Avatar, { AvatarOptions } from '../Avatar';
 import CircleAroundIcon from '../CircleAroundIcon';
+import Paragraph from '../Paragraph';
 import { convertRemToPixels } from '../../utils/utils';
 import { StyledScreenReaderOnly } from '../visuallyHidden';
 
@@ -110,8 +110,7 @@ const StyledDivHeading = styled.div`
     text-overflow: ellipsis;
 `;
 
-const StyledPMessage = styled.p<{isError : boolean}>`
-    ${ ({theme}) => theme.typography.p3 }
+const StyledPMessage = styled(Paragraph)<{isError : boolean}>`
     color: ${props => props.isError ? props.theme.color.error : addOpacityToColor(props.theme.color.mainText, props.theme.opacity.subtleMainText) };
     grid-area: message;
     pointer-events: none;
@@ -309,7 +308,7 @@ function DefaultContent({avatar, errorMsg, progress, handleFilePicker, setDrag, 
                     </StyledLabelFile>
                     or drag in form
                 </StyledDivHeading>
-                <StyledPMessage isError = {isError}>
+                <StyledPMessage isError = {isError} size={3}>
                     { isError ? errorMsg : getDefaultMessage() }
                 </StyledPMessage>
 
@@ -378,7 +377,7 @@ function InProgress({progress} : Pick<I_FileUploaderProps, "progress">){
                 <StyledDivHeading>
                     Downloading
                 </StyledDivHeading>
-                <StyledPMessage isError = {false}>
+                <StyledPMessage isError = {false} size={3}>
                     {getDefaultMessage()}
                 </StyledPMessage>
 

--- a/components/form/subcomponents/InputOnlyContainer.tsx
+++ b/components/form/subcomponents/InputOnlyContainer.tsx
@@ -2,6 +2,8 @@ import styled, {css} from 'styled-components';
 
 import { addOpacityToColor } from '../../../utils/utils';
 
+import Paragraph from '../../Paragraph';
+
 const StyledInputContainer = styled.div<{disabled : boolean, isError : boolean, isSuccess : boolean, readOnly : boolean}>`
     border-radius: ${ ({theme}) => theme.borderRadius };
     height: 3.5rem;
@@ -47,9 +49,8 @@ const StyledInputContainer = styled.div<{disabled : boolean, isError : boolean, 
     }}
 `;
 
-const StyledDescription = styled.p`
-    ${ ({theme}) => theme.typography.p2 }
-    color: ${({theme}) => addOpacityToColor(theme.color.mainText, theme.opacity.subtleMainText) };
+const StyledDescription = styled(Paragraph)`
+    color: ${ ({theme}) => addOpacityToColor(theme.color.mainText, theme.opacity.subtleMainText) };
     margin-top: 0.5rem;
 `;
 
@@ -78,7 +79,7 @@ export default function InputContainer({description, disabled, errorMsg, isSucce
         </StyledInputContainer>
         {
             description !== undefined ?
-                <StyledDescription>
+                <StyledDescription size={2}>
                     {description}
                 </StyledDescription>
                 : null


### PR DESCRIPTION
Imported Paragraph and Heading for use in other styled-components (previously: several components had styled p or h# tags, with the typography pulled in from the theme).