### PR TITLE
Accessibility. ContextMenu usable via keyboard.

### DIFF
--- a/components/Heading.tsx
+++ b/components/Heading.tsx
@@ -11,13 +11,14 @@ const StyledH = styled.div<{level : number}>`
 `;
 
 interface I_Heading{
+    className?: string,
     level?: 1 | 2 | 3 | 4 | 5 | 6,
     children : React.ReactNode,
 }
 
-export default function Heading({level, children} : I_Heading){
+export default function Heading({className, level, children} : I_Heading){
     level = level ?? 1;
-    return  <StyledH as={`h${level}`} level={level}>
+    return  <StyledH as={`h${level}`} level={level} className={className}>
                 {children}
             </StyledH>
 }

--- a/components/Island.tsx
+++ b/components/Island.tsx
@@ -186,7 +186,7 @@ interface I_IslandProps{
 export default function Island({progress, subject, text, heading, description, buttonLabel, studentReq, penReq, onClick} : I_IslandProps){
     const isInProgress = progress !== undefined;
     const theme = isInProgress ? InProgressTheme : DefaultTheme;
-    
+
     if(buttonLabel === undefined){
         buttonLabel = isInProgress ? "Continue" : "Begin";
     }

--- a/components/contextMenu/ContextMenu.stories.tsx
+++ b/components/contextMenu/ContextMenu.stories.tsx
@@ -10,28 +10,30 @@ import ContextMenu, { StyledContextMenu } from './ContextMenu';
 import ContextRadioGroup from './ContextMenuRadio';
 import ContextCheckboxGroup from './ContextMenuCheckbox';
 
+
 export default {
     title: 'UI Kit/ContextMenu',
     component: ContextMenu,
   } as ComponentMeta<typeof ContextMenu>;
 
 // Wrapper for the "RightClickToView" story
-const PARENT_COLOUR = "yellow"; // This is also inserted in the middle of a human-readable sentence, so maybe avoid hex/RGB etc.
-const StyledContainer = styled.div`
+const StyledTarget = styled.div`
     ${({theme}) => theme.typography.p2}
     width: 50vw;
-    height: 10vh;
-    background: ${PARENT_COLOUR};
+    height: 15vh;
+    background: ${ ({theme}) => theme.color.primary };
     padding: 1rem;
     box-sizing: border-box;
+    color: ${ ({theme}) => theme.color.textOnPrimary };
 `;
+
 
 // Positioning for the "I just want to see it, don't make me right click things!" stories
 const POS_X = 16;
 const POS_Y = 16;
 
 export const RightClickRadio: ComponentStory<typeof ContextMenu> = args =>{
-    const containerRef = React.useRef<HTMLDivElement>(null);
+    const targetRef = React.useRef<HTMLDivElement>(null);
 
     const [countries, setCountries] = React.useState<RadioOptionDataType[]>(COUNTRY_RADIO_DATA);
 
@@ -41,9 +43,12 @@ export const RightClickRadio: ComponentStory<typeof ContextMenu> = args =>{
 
     const id_countries = React.useId();
 
-    return <StyledContainer ref={containerRef}>
-                <p>Right click in the {PARENT_COLOUR} area to open context menu</p>
-                <ContextMenu    parentRef = {containerRef}>
+    return <>
+                <StyledTarget ref={targetRef}>
+                    <p>Right click in this square or click the button to open radio context menu</p>
+                </StyledTarget>
+
+                <ContextMenu    targetRef = {targetRef}>
                     <ContextRadioGroup  id={id_countries}
                                         options = {countries}
                                         onChange = {changeCountries}
@@ -52,7 +57,35 @@ export const RightClickRadio: ComponentStory<typeof ContextMenu> = args =>{
                                         hideLegendVisually={true}
                     />
                 </ContextMenu>
-            </StyledContainer>
+            </>
+}
+
+
+export const RightClickCheckbox: ComponentStory<typeof ContextMenu> = args =>{
+    const targetRef = React.useRef<HTMLDivElement>(null);
+
+    const [countries, setCountries] = React.useState<CheckboxOptionDataType[]>(COUNTRY_CHECKBOX_DATA.slice(0,2));
+
+    function changeCountries(id : string, checked : boolean){
+        onChangeCheckbox(id, checked, countries, setCountries);
+    }
+
+    const id_countries = React.useId();
+
+    return <>
+                <StyledTarget ref={targetRef}>
+                    <p>Right click in this square or click the button to open radio context menu</p>
+                </StyledTarget>
+    
+                <ContextMenu    targetRef = {targetRef}>
+                    <ContextCheckboxGroup   id={id_countries}
+                                            options = {countries}
+                                            onChange = {changeCountries}
+                                            legend={"Countries"}
+                                            hideLegendVisually={true}
+                    />
+                </ContextMenu>
+            </>
 }
 
 

--- a/components/contextMenu/ContextMenu.tsx
+++ b/components/contextMenu/ContextMenu.tsx
@@ -1,42 +1,160 @@
-import React, {useState, useEffect} from 'react';
-import styled from 'styled-components';
+import React, {useState, useEffect, useLayoutEffect, useRef } from 'react';
+import styled, { ThemeProvider } from 'styled-components';
 
 import useCloseOnOutsideClick from '../../utils/UseCloseOnOutsideClick';
+import { convertRemToPixels, addOpacityToColor } from '../../utils/utils';
 
-// Exported for use in ContextMenu-related Stories so those stories can display the appearance
-// of the context menu without messing about with the right-clicking behaviour
-export const StyledContextMenu = styled.div<{x : number, y: number}>`
+import {Icon, ICON_ID, ICON_SIZES} from '../icons';
+import { StyledScreenReaderOnly } from '../visuallyHidden';
+import { moveWithinMenu } from '../form/utils/moveWithinMenu';
+
+// Exported for use in ContextMenu-related Stories, so they can display the appearance
+// of a context menu without the behaviour
+export const StyledContextMenu = styled.div.attrs((props : {x : number, y: number}) => {
+    // These positions update when the user resizes the screen. Styled-components would
+    // respond by generating hundreds of CSS classes, so instead chuck this into the DOM
+    // element's style parameter and let React handle it gracefully.
+    return {
+        style: {
+            top: props.y + "px",
+            left: props.x + "px",
+        }
+    }
+})<{x : number, y: number}>`
     background: ${ ({theme}) => theme.color.mainBackground };
     border-radius: ${ ({theme}) => theme.borderRadius };
     box-shadow: ${ ({theme}) => theme.shadow.contextMenu };
-    left: ${props => props.x}px;
     max-width: 100vw;
     overflow: hidden;
     padding: 0.25rem 0 0.35rem;
     position: fixed;
-    top: ${props => props.y}px;
     width: 15.25rem;
 `;
 
-interface ContextMenuProps{
-    parentRef: React.RefObject<HTMLElement>,
+
+const StyledContextMenuButton = styled.button.attrs((props : { pos : null | {x: number, y: number} }) => {
+    // These positions update when the user resizes the screen. Styled-components would
+    // respond by generating hundreds of CSS classes, so instead chuck this into the DOM
+    // element's style parameter and let React handle it gracefully.
+    return {
+        style: {
+            top: props.pos ? props.pos.y + "px" : "0px",
+            left: props.pos ? props.pos.x + "px" : "0px",
+        }
+    }
+})<{ pos : null | {x: number, y: number} }>`
+    background: ${ ({theme}) => theme.color.textOnPrimary };
+    border-radius: 50%;
+    min-width: ${ ICON_SIZES.small };
+    padding: 0.0625rem 0.1875rem 0.1875rem 0.0625rem;
+    position: fixed;
+
+    svg path {
+        fill: ${ ({theme}) => theme.color.primary };
+    }
+
+    &:focus {
+        outline-color: ${ ({theme}) => addOpacityToColor(theme.color.focusOutline, theme.opacity.focusOutline) };
+    }
+
+    &:hover{
+        svg path {
+            fill: ${ ({theme}) => addOpacityToColor(theme.color.primary, theme.opacity.alphaStrong) };
+        }
+    }
+`;
+
+
+interface I_ContextMenuProps{
+    targetRef: React.RefObject<HTMLElement>,
     children?: React.ReactNode
 }
 
-export default function ContextMenu({ parentRef, children } : ContextMenuProps){
-    const contextMenuRef = React.useRef(null);
-    const {isVisible, posX, posY} = useContextMenu({parentRef, contextMenuRef});
+export default function ContextMenu({ targetRef, children } : I_ContextMenuProps){
+    const contextMenuRef = useRef(null);
+    const buttonRef = useRef(null);
+    const {isVisible, posX, posY, btnPos, keyboardMode, openWithButton, handleKeyDown } = useContextMenu({targetRef, contextMenuRef, buttonRef});
 
-    return isVisible ?  <StyledContextMenu x={posX} y={posY} ref={contextMenuRef}>
-                            {children}
-                        </StyledContextMenu>
-                    : null;
+    return isVisible ?  
+                <StyledContextMenu ref={contextMenuRef} x={posX} y={posY} onKeyDown={(e) => handleKeyDown(e)}>
+                    <ThemeProvider theme={ {keyboardMode} }>
+                        {children}
+                    </ThemeProvider>
+                </StyledContextMenu>
+                : 
+                <StyledContextMenuButton ref={buttonRef} pos={btnPos} onClick={(e) => openWithButton(e)}>
+                    <Icon id={ICON_ID.contextMenu} size={ICON_SIZES.small} />
+                    <StyledScreenReaderOnly>
+                        Open context menu
+                    </StyledScreenReaderOnly>
+                </StyledContextMenuButton>
 }
 
-function useContextMenu({parentRef, contextMenuRef} : any){
-    const [isVisible, setIsVisible] = useState(false);
-    const [posX, setPosX] = useState(0);
-    const [posY, setPosY] = useState(0);
+type T_UseContextMenuProps = 
+    Pick<I_ContextMenuProps, "targetRef"> 
+    & {
+        buttonRef : React.MutableRefObject<HTMLButtonElement | null>,
+        contextMenuRef : React.MutableRefObject<HTMLDivElement | null>,
+};
+type T_Pos = { 
+    x: number, 
+    y: number 
+};
+type T_UseContextMenuOutput = {
+    btnPos : T_Pos,
+    isVisible : boolean,
+    keyboardMode : boolean,
+    posX: number,
+    posY: number,
+    handleKeyDown : (e : React.KeyboardEvent) => void,
+    openWithButton : (e : React.MouseEvent<HTMLButtonElement, MouseEvent>) => void,
+};
+function useContextMenu({buttonRef, contextMenuRef, targetRef} 
+    : T_UseContextMenuProps)
+    : T_UseContextMenuOutput {
+
+    const btnPos : T_Pos = useButtonNearTarget({targetRef, buttonRef});
+
+    const { x, y, setPosition } : ReturnType<typeof useContextMenuPositioning> 
+        = useContextMenuPositioning({targetRef, contextMenuRef, btnPos});
+
+    const { closeMenu, isVisible, openWithButton } : ReturnType<typeof useContextMenuVisibility>
+        = useContextMenuVisibility({ contextMenuRef, targetRef, setPosition });
+
+    const { keyboardMode, handleKeyDown, openWithButton : keyboardOpenWithButton } : ReturnType<typeof useKeyboardToOperate> 
+        = useKeyboardToOperate({buttonRef, closeMenu, contextMenuRef, isVisible});
+
+
+    function openWithButtonWithKeyboardSupport(e : React.MouseEvent<HTMLButtonElement, MouseEvent>){
+        keyboardOpenWithButton(e);
+        openWithButton(e);
+    }
+
+    return {
+        btnPos,
+        isVisible,
+        keyboardMode,
+        posX: x,
+        posY: y,
+        handleKeyDown,
+        openWithButton: openWithButtonWithKeyboardSupport,
+    }
+}
+
+
+type T_VisibilityProps = 
+    Pick<T_UseContextMenuProps, "contextMenuRef" | "targetRef">
+    & {
+        setPosition : (e : MouseEvent | React.MouseEvent<HTMLButtonElement, MouseEvent> | React.KeyboardEvent, openedWithRightClick : boolean) => void,
+};
+type T_VisibilityOutput = 
+    Pick<T_UseContextMenuOutput, "isVisible" | "openWithButton">
+    & Pick<T_KeyboardOperationProps, "closeMenu">;
+function useContextMenuVisibility({contextMenuRef, targetRef, setPosition}
+    : T_VisibilityProps)
+    : T_VisibilityOutput {
+
+    const [isVisible, setIsVisible] = useState<boolean>(false);
 
     useCloseOnOutsideClick({
         isOpen : isVisible,
@@ -44,33 +162,175 @@ function useContextMenu({parentRef, contextMenuRef} : any){
         setIsOpen : setIsVisible
     });
 
+
     useEffect(() => {
-        if(!parentRef || !parentRef.current){
+        if(!targetRef || !targetRef.current){
             return;
         }
 
-        let parent = parentRef.current;
+        let target = targetRef.current;
 
         const showMenu = (e : MouseEvent) => {
             e.preventDefault();
-            setIsVisible(true);
-            setPosX(e.clientX);
-            setPosY(e.clientY);
+            openMenu(e, true);
         }
 
-        parent.addEventListener('contextmenu', showMenu);
+        target.addEventListener('contextmenu', showMenu);
 
         return function cleanup(){
-            parent?.removeEventListener('contextmenu', showMenu);
+            target?.removeEventListener('contextmenu', showMenu);
         }
-
     });
 
-    React.useLayoutEffect(() => {
-        if(!contextMenuRef || !contextMenuRef.current){
+
+    function openWithButton(e : React.MouseEvent<HTMLButtonElement, MouseEvent>){
+        e.preventDefault();
+        e.stopPropagation();
+        openMenu(e);
+    }
+
+
+    function openMenu(e : MouseEvent | React.MouseEvent<HTMLButtonElement, MouseEvent>, openedWithRightClick : boolean = false){
+        setPosition(e, openedWithRightClick);
+        setIsVisible(true);
+    }
+
+
+    function closeMenu(){
+        setIsVisible(false);
+    }
+
+    return { 
+        closeMenu, 
+        isVisible, 
+        openWithButton
+    }
+}
+
+
+type T_MenuPositioningProps = 
+    Pick<T_UseContextMenuProps, "contextMenuRef">
+    & {
+        btnPos : T_Pos,
+};
+type T_MenuPositioningOutput = 
+    T_Pos 
+    & Pick<T_VisibilityProps, "setPosition">;
+function useContextMenuPositioning({targetRef, contextMenuRef, btnPos}
+    : T_MenuPositioningProps & Pick<I_ContextMenuProps, "targetRef">)
+    : T_MenuPositioningOutput {
+
+    const [posX, setPosX] = useState(0);
+    const [posY, setPosY] = useState(0);
+
+    const expectedMenuWidth = React.useRef(convertRemToPixels(15.25));
+    const spacer = 2;
+
+    function setPosition(e : MouseEvent | React.MouseEvent<HTMLButtonElement, MouseEvent> | React.KeyboardEvent, openedWithRightClick : boolean){
+        if(openedWithRightClick && "clientX" in e && "clientY" in e){
+            setPosX(e.clientX);
+            setPosY(e.clientY);
             return;
         }
-        let pos = contextMenuRef.current.getBoundingClientRect();
+
+        if(targetRef && targetRef.current){
+            const rect = targetRef.current.getBoundingClientRect();
+            setPosX(rect.right - expectedMenuWidth.current - spacer);
+            setPosY(rect.top);
+            return;
+        }
+
+        if(btnPos){
+            setPosX(btnPos.x - expectedMenuWidth.current - spacer);
+            setPosY(btnPos.y);
+            return;
+        }
+
+        setPosX(0);
+        setPosY(0);
+    }
+
+    usePositionWithinResizedWindow({
+        ref: contextMenuRef,
+        setPosX, 
+        setPosY
+    });
+
+    return {
+        x: posX, 
+        y: posY, 
+        setPosition
+    }
+}
+
+
+function useButtonNearTarget({targetRef, buttonRef} 
+    : Pick<I_ContextMenuProps, "targetRef"> & Pick<T_UseContextMenuProps, "buttonRef">)
+    : T_Pos {
+
+    const [posX, setPosX] = useState<number>(0);
+    const [posY, setPosY] = useState<number>(0);
+
+
+    function positionButton(){
+        if(!targetRef || !targetRef.current){
+            return;
+        }
+
+        let rect = targetRef.current.getBoundingClientRect();
+        let x = rect.right;
+        let y = rect.top;
+        setPosX(x);
+        setPosY(y);
+    }
+
+    function addXSpacer(position : number){
+        const xSpacer = 1;
+
+        let buttonWidth = 16;
+        if(buttonRef?.current){
+            buttonWidth = buttonRef.current.getBoundingClientRect().width;
+        }
+
+        return position + xSpacer;
+    }
+
+    useEffect(() => {
+        window.addEventListener("resize", positionButton);
+        return () => window.removeEventListener("resize", positionButton);
+    }, []);
+
+    useLayoutEffect(() => {
+        positionButton();
+    }, [targetRef]);
+
+    usePositionWithinResizedWindow({
+        ref: buttonRef,
+        setPosX, 
+        setPosY
+    });
+
+    return { 
+        x: addXSpacer(posX), 
+        y: posY 
+    };
+}
+
+
+type T_ResponsivePositioningProps = {
+    ref : React.MutableRefObject<any>,
+    setPosX : React.Dispatch<React.SetStateAction<number>>,
+    setPosY : React.Dispatch<React.SetStateAction<number>>,
+}
+function usePositionWithinResizedWindow({ref, setPosX, setPosY}
+    : T_ResponsivePositioningProps)
+    : void {
+
+    function reposition(){
+        if(!ref || !ref.current){
+            return;
+        }
+        let pos = ref.current.getBoundingClientRect();
 
         if(pos.left < 0){
             setPosX(0);
@@ -85,11 +345,147 @@ function useContextMenu({parentRef, contextMenuRef} : any){
         else if(pos.top > 0 && pos.bottom > window.innerHeight){
             setPosY(window.innerHeight - (pos.bottom - pos.top));
         }
-    });
+    }
+
+    useEffect(() => {
+        window.addEventListener("resize", reposition);
+        return () => window.removeEventListener("resize", reposition);
+    }, []);
+
+
+    useLayoutEffect(() => {
+        reposition();
+    }, [ref, setPosX, setPosY]);
+}
+
+
+type T_KeyboardOperationProps = 
+    Pick<T_UseContextMenuProps, "buttonRef" | "contextMenuRef"> 
+    & Pick<T_UseContextMenuOutput, "isVisible">
+    & {
+        closeMenu : () => void,
+};
+type T_KeyboardOperationOutput = 
+    Pick<T_UseContextMenuOutput, "keyboardMode" | "handleKeyDown">
+    & {
+        openWithButton : (e : MouseEvent | React.MouseEvent<HTMLButtonElement, MouseEvent>) => void,
+};
+function useKeyboardToOperate({buttonRef, closeMenu, contextMenuRef, isVisible}:
+    T_KeyboardOperationProps)
+    : T_KeyboardOperationOutput{
+
+    const [keyboardMode, setKeyboardMode] = useState<boolean>(false);
+    const [activeIdx, setActiveIdx] = useState<number | null>(null);
+
+
+    function openWithButton(e : MouseEvent | React.MouseEvent<HTMLButtonElement, MouseEvent>){
+        if(e.detail === 0 && !(e instanceof PointerEvent)){
+            setKeyboardMode(true);
+        }
+    }
+
+
+    function handleKeyDown(e : React.KeyboardEvent){
+        // Handle cases where the user opens the menu with mouse/touch, then switches
+        // to keyboard operation
+        const relevantKeys = ['ArrowUp', 'ArrowDown', 'Space', 'Escape', 'Tab'];
+        if(relevantKeys.includes(e.key)){
+            if(!keyboardMode){
+                setKeyboardMode(true);
+            }
+        }
+
+        if(e.key === "Escape" || e.key === "Tab"){
+            closeMenu();
+        }
+        if(e.key === 'ArrowUp' || e.key === 'ArrowDown'){
+            if(contextMenuRef?.current){
+                moveWithinMenu({
+                    e,
+                    menuItems: contextMenuRef.current.getElementsByTagName("label"),
+                    activeId : activeIdx,
+                    setActiveId : setActiveIdx
+                });
+            }
+        }
+    }
+
+    useContextMenuFocusManagement({
+        keyboardMode, isVisible, contextMenuRef, activeIdx, setActiveIdx, buttonRef, setKeyboardMode});
 
     return {
-        isVisible,
-        posX,
-        posY
+        keyboardMode,
+        handleKeyDown,
+        openWithButton
     }
+}
+
+type T_FocusManagementProps = 
+    Pick<T_UseContextMenuProps, "buttonRef" | "contextMenuRef">
+    & Pick<T_UseContextMenuOutput, "keyboardMode" | "isVisible">
+    & {
+        activeIdx : number | null,
+        setActiveIdx : React.Dispatch<React.SetStateAction<number | null>>, 
+        setKeyboardMode : React.Dispatch<React.SetStateAction<boolean>>,
+};
+function useContextMenuFocusManagement({ activeIdx, buttonRef, contextMenuRef, isVisible, keyboardMode, setActiveIdx, setKeyboardMode}
+    : T_FocusManagementProps)
+    : void {
+
+    useLayoutEffect(() => {
+
+        if(isVisible){
+            handleFocusWhenMenuOpens();
+        }
+        else {
+            handleFocusWhenMenuCloses();
+        }
+
+
+        function handleFocusWhenMenuOpens(){
+            if(!contextMenuRef || !contextMenuRef.current){
+                return;
+            }
+
+            const firstCheckedIdx = getIndexOfFirstChecked();
+            const focusIdx : number = activeIdx !== null ?
+                                        activeIdx
+                                        : firstCheckedIdx !== null ?
+                                            firstCheckedIdx
+                                            : 0;
+
+            const optionToFocus = contextMenuRef.current.getElementsByTagName("label")[focusIdx];
+            optionToFocus.focus();
+
+            if(focusIdx !== activeIdx){
+                setActiveIdx(focusIdx);
+            }
+        }
+
+
+        function getIndexOfFirstChecked() : number | null {
+            if(contextMenuRef?.current){
+                const labels = contextMenuRef.current.getElementsByTagName("label");
+                for(let i = 0; i < labels.length; i++){
+                    const input = labels[i].getElementsByTagName("input")[0];
+                    if(input.checked){
+                        return i;
+                    }
+                }
+            }
+            return null;
+        }
+
+
+        function handleFocusWhenMenuCloses(){
+            // activeIdx === null means the user has not yet used their keyboard to navigate the menu.
+            // It prevents the button component from snatching focus on mounting
+            if(!buttonRef || !buttonRef.current || activeIdx === null){
+                return;
+            }
+            buttonRef.current.focus();
+            setKeyboardMode(false);
+        }
+
+    }, [activeIdx, isVisible, keyboardMode, contextMenuRef, buttonRef, setKeyboardMode, setActiveIdx]);
 }

--- a/components/contextMenu/ContextMenuCheckbox.tsx
+++ b/components/contextMenu/ContextMenuCheckbox.tsx
@@ -4,7 +4,7 @@ import { Icon, ICON_ID, ICON_SIZES } from '../icons/';
 import { StyledScreenReaderOnly } from '../visuallyHidden';
 import { CheckboxOptionDataType } from '../form/';
 
-import ContextMenuFieldset, { I_ContextMenuFieldset, StyledContextOption } from './ContextMenuFieldset';
+import ContextMenuGroup, { I_ContextMenuFieldset, StyledContextOption } from './ContextMenuFieldset';
 
 interface I_CheckboxProps extends I_ContextMenuFieldset{
     onChange : (id : string, checked : boolean) => void, /* ID to find the element; checked to update based on what the user can see */
@@ -13,7 +13,7 @@ interface I_CheckboxProps extends I_ContextMenuFieldset{
 
 export default function ContextCheckboxGroup({hideLegendVisually, id, legend, onChange, options} : I_CheckboxProps){
     const optionPrefix = id + "-opt";
-    return  <ContextMenuFieldset    hideLegendVisually={hideLegendVisually}
+    return  <ContextMenuGroup    hideLegendVisually={hideLegendVisually}
                                     id={id}
                                     legend={legend}
                                     >
@@ -29,7 +29,7 @@ export default function ContextCheckboxGroup({hideLegendVisually, id, legend, on
                                             />
                     })
                 }
-            </ContextMenuFieldset>
+            </ContextMenuGroup>
 }
 
 type CheckboxOptionType = CheckboxOptionDataType & {
@@ -38,6 +38,7 @@ type CheckboxOptionType = CheckboxOptionDataType & {
 }
 function ContextCheckbox({checked, id, name, displayText, onChange, htmlId} : CheckboxOptionType){
     // isHighlighted is used when custom keyboard operation is applied. This is using native HTML, so no need.
+
     return  <StyledContextOption as={"label"} isHighlighted={false}>
                 {displayText}
 

--- a/components/contextMenu/ContextMenuFieldset.tsx
+++ b/components/contextMenu/ContextMenuFieldset.tsx
@@ -26,6 +26,10 @@ const StyledLegend = styled.legend`
 `;
 
 export const StyledContextOption = styled(StyledOptionWithCheck)`
+    &:focus-within {
+        background: ${ ({theme}) => theme.keyboardMode ? theme.color.inputBackgroundHoverLight : "auto" };
+    }
+
     svg{
         right: 0.5rem;
     }
@@ -45,7 +49,7 @@ export default function ContextMenuFieldset({hideLegendVisually, id, legend, chi
     hideLegendVisually = hideLegendVisually ?? false;
 
     return  <StyledFieldSet id={id}>
-
+    
                 { hideLegendVisually ?
                     <StyledScreenReaderOnly as="legend">
                         {legend}
@@ -60,3 +64,5 @@ export default function ContextMenuFieldset({hideLegendVisually, id, legend, chi
 
             </StyledFieldSet>
 }
+
+

--- a/components/contextMenu/ContextMenuRadio.tsx
+++ b/components/contextMenu/ContextMenuRadio.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Icon, ICON_ID, ICON_SIZES } from '../icons/';
 import { StyledScreenReaderOnly } from '../visuallyHidden';
 
-import ContextMenuFieldset, { I_ContextMenuFieldset, StyledContextOption } from './ContextMenuFieldset';
+import ContextMenuGroup, { I_ContextMenuFieldset, StyledContextOption } from './ContextMenuFieldset';
 import { RadioOptionDataType } from '../form/';
 
 interface I_RadioProps extends I_ContextMenuFieldset{
@@ -14,7 +14,7 @@ interface I_RadioProps extends I_ContextMenuFieldset{
 
 export default function ContextRadioGroup({hideLegendVisually, id, legend, name, onChange, options} : I_RadioProps){
     const optionPrefix = id + "-opt";
-    return  <ContextMenuFieldset    hideLegendVisually={hideLegendVisually}
+    return  <ContextMenuGroup    hideLegendVisually={hideLegendVisually}
                                     id={id}
                                     legend={legend}
                                     >
@@ -30,7 +30,7 @@ export default function ContextRadioGroup({hideLegendVisually, id, legend, name,
                                             />
                     })
                 }
-            </ContextMenuFieldset>
+            </ContextMenuGroup>
 }
 
 
@@ -47,7 +47,7 @@ function ContextRadio({checked, id, displayText, onChange, name : groupName, htm
                     : null
                 }
                 <StyledScreenReaderOnly     as="input"
-                                            type="radio" 
+                                            type="radio"
                                             onChange={() => onChange()} 
                                             checked={checked} 
                                             id={htmlId}

--- a/components/form/SelectText.tsx
+++ b/components/form/SelectText.tsx
@@ -24,7 +24,7 @@ const StyledSelectedInput = styled.div`
 `;
 
 const StyledPlaceholderSpan = styled.span`
-    opacity: 48%;
+    opacity: ${ ({theme}) => theme.opacity.placeholderText };
 `;
 
 const StyledFloatingLabel = styled(StyledLabel)<{floatUp : boolean}>`

--- a/components/form/subcomponents/Option.tsx
+++ b/components/form/subcomponents/Option.tsx
@@ -42,7 +42,7 @@ export const StyledOption = styled.div<{isHighlighted : boolean}>`
         text-overflow: ellipsis;
     }
 
-    &:hover{
+    &:hover {
         background: ${ ({theme}) => theme.color.inputBackgroundHoverDark };
         cursor: url(${customCursorImg}), auto;
     }

--- a/components/form/utils/UseOptionsList.tsx
+++ b/components/form/utils/UseOptionsList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import useCloseOnOutsideClick from '../../../utils/UseCloseOnOutsideClick';
+import { moveWithinMenu } from './moveWithinMenu';
 
 import { SelectOptionDataType, I_SelectWrapperProps } from '../';
 
@@ -115,7 +116,7 @@ export function selectMenuKeyDown({e, options, optionsVisible, activeId, closeOp
             return;
         }
 
-        moveWithinMenu({e, options, activeId, setActiveId});
+        moveWithinMenu({e, menuItems: options, activeId, setActiveId});
     }
 
     if(e.key === 'Enter' || e.key === 'Space'){
@@ -132,33 +133,3 @@ export function selectMenuKeyDown({e, options, optionsVisible, activeId, closeOp
 }
 
 
-function moveWithinMenu({e, options, activeId, setActiveId} 
-    : Pick<T_SelectMenuKeydownProps, "e" | "activeId" | "options" | "setActiveId">
-    ){
-
-    if(options === null || options === undefined){
-        return;
-    }
-
-    let newId = activeId;
-
-    if(e.key === 'ArrowUp'){
-        if(newId === null || newId <= 0 ){ /* Loop from top to bottom */
-            newId = options.length - 1;
-        }
-        else{
-            newId--;
-        }
-    }
-    
-    if(e.key === 'ArrowDown'){
-        if(newId === null || newId >= options.length - 1 ){ /* Loop from bottom to top */
-            newId = 0;
-        }
-        else{
-            newId++;
-        }
-    }
-
-    setActiveId(newId);
-}

--- a/components/form/utils/moveWithinMenu.tsx
+++ b/components/form/utils/moveWithinMenu.tsx
@@ -1,0 +1,41 @@
+/*
+    Handle ArrowUp and ArrowDown incrementing/decrementing an activeIndex
+*/
+
+interface I_MenuMovementProps{
+    e : React.KeyboardEvent<any>,
+    menuItems : any[] | HTMLCollectionOf<any>,
+    activeId : number | null,
+    setActiveId : (value : React.SetStateAction<number | null>) => void,
+}
+
+export function moveWithinMenu({e, menuItems, activeId, setActiveId} 
+    : I_MenuMovementProps)
+    : void {
+
+    if(menuItems === null || menuItems === undefined){
+        return;
+    }
+
+    let newId = activeId;
+
+    if(e.key === 'ArrowUp'){
+        if(newId === null || newId <= 0 ){ /* Loop from top to bottom */
+            newId = menuItems.length - 1;
+        }
+        else{
+            newId--;
+        }
+    }
+    
+    if(e.key === 'ArrowDown'){
+        if(newId === null || newId >= menuItems.length - 1 ){ /* Loop from bottom to top */
+            newId = 0;
+        }
+        else{
+            newId++;
+        }
+    }
+
+    setActiveId(newId);
+}

--- a/components/icons/Icon.stories.tsx
+++ b/components/icons/Icon.stories.tsx
@@ -123,6 +123,7 @@ const IdsInFigmaOrder = {
         ICON_ID.starEmpty,
         ICON_ID.starFilled,
         ICON_ID.close,
+        ICON_ID.contextMenu,
     ],
     [ICON_SIZES.medium]: [
         ICON_ID.copy,

--- a/components/icons/IconRecords.tsx
+++ b/components/icons/IconRecords.tsx
@@ -26,6 +26,7 @@ export const ICON_ID = {
     check: "check",
     close: "close",
     closeBig: "closeBig",
+    contextMenu: "contextMenu",
     copy: "copy",
     default: "default",
     eyeClosed: "eyeClosed",
@@ -142,6 +143,9 @@ export const IconRecords : Record<keyof typeof ICON_ID, T_AnyIconSizeComboButNot
         [ICON_SIZES.small]: CheckS,
         [ICON_SIZES.medium]: CheckM,
         [ICON_SIZES.extraLarge]: CheckXL,
+    },
+    [ICON_ID.contextMenu]: {
+        [ICON_SIZES.small]: ContextMenuS,
     },
     [ICON_ID.close]: {
         [ICON_SIZES.small]: CloseS,
@@ -424,6 +428,11 @@ function CloseL(size : string) : JSX.Element {
 function CloseBigM(size : string) : JSX.Element {
     return  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                 <path fillRule="evenodd" clipRule="evenodd" d="M3.50256 18.0692C2.83215 18.7396 2.83215 19.8265 3.50256 20.4969C4.17296 21.1673 5.2599 21.1673 5.93031 20.4969L11.9999 14.4273L18.0699 20.4972C18.7403 21.1676 19.8272 21.1676 20.4976 20.4972C21.168 19.8268 21.168 18.7399 20.4976 18.0695L14.4277 11.9995L20.4968 5.93043C21.1672 5.26002 21.1672 4.17309 20.4968 3.50268C19.8264 2.83228 18.7395 2.83228 18.0691 3.50268L11.9999 9.57179L5.93113 3.50299C5.26072 2.83258 4.17378 2.83258 3.50338 3.50299C2.83297 4.17339 2.83297 5.26033 3.50338 5.93074L9.57219 11.9995L3.50256 18.0692Z" fill="#111111"/>
+            </svg>
+}
+function ContextMenuS(size : string) : JSX.Element {
+    return  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path fillRule="evenodd" clipRule="evenodd" d="M8.5 16C12.6421 16 16 12.6421 16 8.5C16 4.35786 12.6421 1 8.5 1C4.35786 1 1 4.35786 1 8.5C1 12.6421 4.35786 16 8.5 16ZM4.5 10C5.32843 10 6 9.32843 6 8.5C6 7.67157 5.32843 7 4.5 7C3.67157 7 3 7.67157 3 8.5C3 9.32843 3.67157 10 4.5 10ZM14 8.5C14 9.32843 13.3284 10 12.5 10C11.6716 10 11 9.32843 11 8.5C11 7.67157 11.6716 7 12.5 7C13.3284 7 14 7.67157 14 8.5ZM8.5 10C9.32843 10 10 9.32843 10 8.5C10 7.67157 9.32843 7 8.5 7C7.67157 7 7 7.67157 7 8.5C7 9.32843 7.67157 10 8.5 10Z" fill="#D4D4D4"/>
             </svg>
 }
 function CopyS(size : string) : JSX.Element {

--- a/components/tooltip/TooltipBubble.tsx
+++ b/components/tooltip/TooltipBubble.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import styled, {ThemeProps, ThemeProvider} from 'styled-components';
 
-// import { LAYOUT, PALETTE, SHADOW } from '../../utils/Theme';
-
 import { theme as themeObj } from '../../styles/theme';
 
 import Paragraph from '../Paragraph';


### PR DESCRIPTION
Add button for opening ContextMenu (previous: could only be opened via right-click).
Enable keyboard navigation of ContextMenu options.
Add functional story for Checkbox mode (Checkbox and Radio work slightly differently).
Add SVG icon for ContextMenu.
Add className property to Heading.
