### PR TITLE
BugFix. TooltipBubble arrow.

### DIFF
--- a/components/tooltip/TooltipBubble.tsx
+++ b/components/tooltip/TooltipBubble.tsx
@@ -226,6 +226,7 @@ const StyledTooltip = styled(StyledTooltipBase)`
 
     &:after{
         background: ${props => props.backgroundColor};
+        height: 0.3125rem;
         width: 0.75rem;
         
         ${props => props.theme.xKey}: ${ props => props.theme.pos.x.fill};


### PR DESCRIPTION
Bug: the white triangle "arrow" on the TooltipBubble was failing to completely cover the grey border around the rectangle -- leaving a 1px grey line going along the arrow's base -- but only when pointing downwards.

Cause: with a width of 0.75rem, the calculated height of the arrow was 4.98px. The visibility of the grey line was caused by how the browser rendered the fraction of a pixel.

Solution: declaring a height of 0.3125rem sets the height to a round 5px: the grey line is now correctly covered in all four directions.
